### PR TITLE
support yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dtoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +416,12 @@ name = "libc"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -658,6 +670,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "serial_test"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,9 +734,11 @@ version = "0.1.2"
 dependencies = [
  "assert_cmd",
  "async-std",
+ "lazy_static",
  "nix",
  "predicates",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "shlex",
 ]
@@ -908,3 +934,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ serde_json = "1.0.64"
 shlex = "1.0.0"
 nix = "0.20.0"
 assert_cmd = "1.0.3"
+serde_yaml = "0.8.17"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 predicates = "1.0.7"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -27,6 +27,7 @@ crossbeam-utils,https://github.com/crossbeam-rs/crossbeam,Apache-2.0 OR MIT,The 
 ctor,https://github.com/mmastrac/rust-ctor,Apache-2.0 OR MIT,Matt Mastracci <matthew@mastracci.com>
 difference,https://github.com/johannhof/difference.rs,MIT,Johann Hofmann <mail@johann-hofmann.com>
 doc-comment,https://github.com/GuillaumeGomez/doc-comment,MIT,Guillaume Gomez <guillaume1.gomez@gmail.com>
+dtoa,https://github.com/dtolnay/dtoa,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
 event-listener,https://github.com/stjepang/event-listener,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 fastrand,https://github.com/stjepang/fastrand,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 float-cmp,https://github.com/mikedilger/float-cmp,MIT,Mike Dilger <mike@mikedilger.com>
@@ -42,6 +43,7 @@ js-sys,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys,Apache
 kv-log-macro,https://github.com/yoshuawuyts/kv-log-macro,Apache-2.0 OR MIT,Yoshua Wuyts <yoshuawuyts@gmail.com>
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,Apache-2.0 OR MIT,Marvin Löbel <loebel.marvin@gmail.com>
 libc,https://github.com/rust-lang/libc,Apache-2.0 OR MIT,The Rust Project Developers
+linked-hash-map,https://github.com/contain-rs/linked-hash-map,Apache-2.0 OR MIT,Stepan Koltsov <stepan.koltsov@gmail.com>|Andrew Paseltiner <apaseltiner@gmail.com>
 lock_api,https://github.com/Amanieu/parking_lot,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
 log,https://github.com/rust-lang/log,Apache-2.0 OR MIT,The Rust Project Developers
 memchr,https://github.com/BurntSushi/rust-memchr,MIT OR Unlicense,Andrew Gallant <jamslam@gmail.com>|bluss
@@ -70,6 +72,7 @@ ryu,https://github.com/dtolnay/ryu,Apache-2.0 OR BSL-1.0,David Tolnay <dtolnay@g
 scopeguard,https://github.com/bluss/scopeguard,Apache-2.0 OR MIT,bluss
 serde,https://github.com/serde-rs/serde,Apache-2.0 OR MIT,Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com>
 serde_json,https://github.com/serde-rs/json,Apache-2.0 OR MIT,Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com>
+serde_yaml,https://github.com/dtolnay/serde-yaml,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
 serial_test,https://github.com/palfrey/serial_test/,MIT,Tom Parker-Shemilt <palfrey@tevp.net>
 serial_test_derive,https://github.com/palfrey/serial_test/,MIT,Tom Parker-Shemilt <palfrey@tevp.net>
 shlex,https://github.com/comex/rust-shlex,Apache-2.0 OR MIT,comex <comexk@gmail.com>|Fenhl <fenhl@fenhl.net>
@@ -97,3 +100,4 @@ wepoll-sys,https://gitlab.com/yorickpeterse/wepoll-sys,MPL-2.0,Yorick Peterse <y
 winapi,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>
 winapi-i686-pc-windows-gnu,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>
 winapi-x86_64-pc-windows-gnu,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>
+yaml-rust,https://github.com/chyh1990/yaml-rust,Apache-2.0 OR MIT,Yuheng Chen <yuhengchen@sensetime.com>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ensure you have the latest stable Rust toolchain enabled.
 
 ## Usage
 
-Create a JSON file with the following properties.
+Create a JSON or YAML file with the following properties.
 
 * **`run`**: The command to run and test. You can format this like a shell
   command with arguments, but note that it will not use a shell as an

--- a/examples/simple.yml
+++ b/examples/simple.yml
@@ -1,0 +1,2 @@
+setup: echo a setup was run
+run: bash -c "echo udp.data:50\|g > /dev/udp/127.0.0.1/8125"

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -15,8 +15,14 @@ macro_rules! run {
 
 #[test]
 #[serial]
-fn simple() {
+fn simple_json() {
     run!("examples/simple.json").assert().success();
+}
+
+#[test]
+#[serial]
+fn simple_yml() {
+    run!("examples/simple.yml").assert().success();
 }
 
 #[test]


### PR DESCRIPTION
### What does this PR do?

Switches the config parsing library from serde_json to serde_yaml to add support
for YAML config files.

### Motivation

JSON is a subset of YAML anyway, so by switching the parser to
serde_yaml, we get both formats for the price of one.

YAML support meas compatability with a wider variety of tools.

### Checklist

[x] I have added tests for the code I am submitting
