### PR TITLE
fix: handle socket bind error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,10 +27,10 @@ mod config;
 use config::get_config;
 
 async fn statsd_listener(barrier: Arc<Barrier>, statsd_buf: Arc<RwLock<String>>) -> Result<String> {
-    let socket = UdpSocket::bind("127.0.0.1:8124").await;
+    let socket = UdpSocket::bind("127.0.0.1:8125").await;
     let socket = match socket {
         Ok(s) => s,
-        Err(error) => panic!("Cannot bind to 127.0.0.1:8124: {}", error),
+        Err(error) => panic!("Cannot bind to 127.0.0.1:8125: {}", error),
     };
     barrier.wait().await; // indicates to main task that socket is listening
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,11 @@ mod config;
 use config::get_config;
 
 async fn statsd_listener(barrier: Arc<Barrier>, statsd_buf: Arc<RwLock<String>>) -> Result<String> {
-    let socket: UdpSocket = UdpSocket::bind("127.0.0.1:8125").await?;
+    let socket = UdpSocket::bind("127.0.0.1:8124").await;
+    let socket = match socket {
+        Ok(s) => s,
+        Err(error) => panic!("Cannot bind to 127.0.0.1:8124: {}", error),
+    };
     barrier.wait().await; // indicates to main task that socket is listening
 
     loop {


### PR DESCRIPTION
### What does this PR do?

Apologies for the poor Rust quality. I thought it would be good if socket bind errors are dealt with, otherwise the user would see this hanging without knowing what's going on.

### Motivation

I had to run the Datadog agent, which by default is listening to 8125. This prevented the socket from sirun to bind, resulting in a hang.

### Related issues

N.A.

### Additional Notes

I'm aware the plan is to allow customising the socket from the command line, but it would be nice to warn in case of problems so that the appropriate actions can be taken 🙂 

### Checklist

[] I have added tests for the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
