### PR TITLE
Ensure results are sorted JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This will output something like the following.
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-results: {"version": "123abc", "name": "test_some_stuff", "user.time": "6389", "system.time": "8737", "udp.data": "50", "max.res.size": "2240512"}
+{"version": "123abc", "name": "test_some_stuff", "user.time": "6389", "system.time": "8737", "udp.data": "50", "max.res.size": "2240512"}
 ```
 
 ## License

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use nix::{
     libc::{getrusage, RUSAGE_CHILDREN},
     unistd,
 };
+use serde_json::json;
 use std::{
     collections::HashMap,
     env,
@@ -155,6 +156,6 @@ async fn main() {
     get_kernel_metrics(&mut metrics);
     get_statsd_metrics(&mut metrics, statsd_buf.read().await.clone());
 
-    println!("results: {:?}", metrics);
+    println!("{}", json!(metrics).to_string());
     exit(0);
 }

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -26,7 +26,7 @@ fn simple_name() {
         .env("SIRUN_NAME", "test test")
         .assert()
         .success()
-        .stdout(predicate::str::contains("\"name\": \"test test\""));
+        .stdout(predicate::str::contains("\"name\":\"test test\""));
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn simple_version() {
         .env("GIT_COMMIT_HASH", "123abc")
         .assert()
         .success()
-        .stdout(predicate::str::contains("\"version\": \"123abc\""));
+        .stdout(predicate::str::contains("\"version\":\"123abc\""));
 }
 
 #[test]


### PR DESCRIPTION
### What does this PR do?

Remove the `results: ` prefix and ensure the printed results JSON keys are sorted.

I was trying to sort the HashMap values but still get it printed as JSON, but it seems like `serde_json` sorts the keys when printing?

### Motivation

Being able to pipe results/read directly without removing `results: `, e.g. `sirun task.json | jq .`