### PR TITLE
add cachegrind support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Stable
+      - name: Install valgrind
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get install valgrind
+          fi
+      - name: Tests
         run: cargo test
       - name: Clippy
         run: |

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -105,3 +105,13 @@ fn stdio() {
         .success()
         .stdout(predicate::str::contains("setup was run").not());
 }
+
+#[cfg(target_arch = "linux")]
+#[test]
+#[serial]
+fn cachegrind() {
+    run!("./examples/cachegrind.json")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"instructions\":"));
+}


### PR DESCRIPTION
### What does this PR do?
- run cachegrind
  - This means, for now, getting the total instruction count and putting it in
    the json result.
- add cachegrind test

### Motivation

Instruction count is a useful data point in benchmarking.

### Checklist

[x] I have added tests for the code I am submitting
[x] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
