### PR TITLE
Support "iterations" option

### DIFF
--- a/examples/iterations.json
+++ b/examples/iterations.json
@@ -1,0 +1,4 @@
+{
+  "run": "bash -c \"echo you should see this\"",
+  "iterations": 3
+}

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -115,3 +115,30 @@ fn cachegrind() {
         .success()
         .stdout(predicate::str::contains("\"instructions\":"));
 }
+
+#[test]
+#[serial]
+fn iterations() {
+    run!("./examples/iterations.json")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "you should see this\nyou should see this\nyou should see this",
+        ));
+    run!("./examples/iterations.json")
+        .env("SIRUN_NO_STDIO", "1")
+        .assert()
+        .success()
+        .stdout(predicate::function(|out| {
+            serde_yaml::from_str::<serde_yaml::Value>(out)
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"iterations".into())
+                .unwrap()
+                .as_sequence()
+                .unwrap()
+                .len()
+                == 3
+        }));
+}


### PR DESCRIPTION
### What does this PR do?
- support 'iterations' option

In JSON/YAML config, this must be set to an integer > 0 or not set at all, which
the default of 1 is used. This instructs sirun to run the test that many times.

This adds an `iterations` field to the output JSON when more than one iteration
is run. Iteration-specific metrics are included here. If only one iteration is
run, the results will instead be at the top level.

### Motivation

Many tests would benefit from collecting more data without having to run the
setup task more than once.

### Checklist

[x] I have added tests for the code I am submitting
[x] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
