### PR TITLE
name in config, variant in output

### DIFF
--- a/examples/simple-name.json
+++ b/examples/simple-name.json
@@ -1,0 +1,4 @@
+{
+  "name": "test test",
+  "run": "bash -c \"exit 0\""
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,8 +238,11 @@ async fn main() -> Result<()> {
     if let Ok(hash) = env::var("GIT_COMMIT_HASH") {
         metrics.insert("version".into(), hash.into());
     }
-    if let Ok(name) = env::var("SIRUN_NAME") {
+    if let Some(name) = config.name {
         metrics.insert("name".into(), name.into());
+    }
+    if let Some(variant) = config.variant {
+        metrics.insert("variant".into(), variant.into());
     }
 
     println!("{}", json!(metrics).to_string());

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -27,9 +27,18 @@ fn simple_yml() {
 
 #[test]
 #[serial]
-fn simple_name() {
+fn simple_name_env() {
     run!("examples/simple.json")
         .env("SIRUN_NAME", "test test")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"name\":\"test test\""));
+}
+
+#[test]
+#[serial]
+fn simple_name() {
+    run!("examples/simple-name.json")
         .assert()
         .success()
         .stdout(predicate::str::contains("\"name\":\"test test\""));
@@ -64,6 +73,12 @@ fn variants() {
         .assert()
         .success()
         .stdout(predicate::str::contains("variant 1"));
+    run!("./examples/variants.json")
+        .env("SIRUN_VARIANT", "1")
+        .env("SIRUN_NO_STDIO", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"variant\":\"1\""));
 }
 
 #[test]


### PR DESCRIPTION
### What does this PR do?

Allows the `"name"` property to be set in the config, rather than solely by
environment variable. Environment variable takes precedence.

Sets the variant as a value in the output JSON.

### Motivation

Not all use cases would set name by environment variable.

Variant is useful information that may not be easily retrievable.

### Checklist

[x] I have added tests for the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
