### PR TITLE
fix timing measurements

### DIFF
--- a/examples/long.json
+++ b/examples/long.json
@@ -1,0 +1,3 @@
+{
+  "run": "bash -c 'end=$((SECONDS+2)); while [ $SECONDS -lt $end ]; do continue; done'"
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,13 @@ fn get_statsd_metrics(metrics: &mut HashMap<String, MetricValue>, udp_data: Stri
     Ok(())
 }
 
+fn ms_from_timeval(tv: nix::libc::timeval) -> f64 {
+    let seconds = tv.tv_sec;
+    let ms = tv.tv_usec as i64;
+    let val = seconds * 1000000 + ms;
+    val as f64
+}
+
 fn get_kernel_metrics(metrics: &mut HashMap<String, MetricValue>) {
     let data = unsafe {
         let mut data = MaybeUninit::zeroed().assume_init();
@@ -96,8 +103,8 @@ fn get_kernel_metrics(metrics: &mut HashMap<String, MetricValue>) {
         data
     };
     metrics.insert("max.res.size".into(), data.ru_maxrss.into());
-    metrics.insert("user.time".into(), data.ru_utime.tv_usec.into());
-    metrics.insert("system.time".into(), data.ru_stime.tv_usec.into());
+    metrics.insert("user.time".into(), ms_from_timeval(data.ru_utime).into());
+    metrics.insert("system.time".into(), ms_from_timeval(data.ru_stime).into());
 }
 
 fn get_stdio() -> Stdio {

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -157,3 +157,22 @@ fn iterations() {
                 == 3
         }));
 }
+
+#[test]
+#[serial]
+fn long() {
+    run!("./examples/long.json")
+        .assert()
+        .success()
+        .stdout(predicate::function(|out| {
+            serde_yaml::from_str::<serde_yaml::Value>(out)
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"user.time".into())
+                .unwrap()
+                .as_f64()
+                .unwrap()
+                > 1000000.0
+        }));
+}


### PR DESCRIPTION
They were previously missing the seconds measurement, and only including
microseconds.
