### PR TITLE
better error on missing env var

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -157,7 +157,8 @@ pub(crate) fn get_config(filename: &str) -> Result<Config> {
     apply_config(&mut config, &config_val)?;
 
     if let Some(variants) = config_val.get("variants") {
-        let variant_key = env::var("SIRUN_VARIANT")?;
+        let variant_key = env::var("SIRUN_VARIANT")
+            .map_err(|_| anyhow!("If variants are present in config, the SIRUN_VARIANT environment variable must be set."))?;
         config.variant = Some(variant_key.clone());
         let config_json = if let Some(variants) = variants.as_sequence() {
             let variant_key = variant_key.parse()?;


### PR DESCRIPTION
### What does this PR do?

When SIRUN_VARIANT is not set, and config requires it, provide a nicer error
message.

### Motivation

The previous error message was unclear as to what was wrong.
