### PR TITLE
fix summmed results in iterations

### DIFF
--- a/examples/iterations.json
+++ b/examples/iterations.json
@@ -1,4 +1,4 @@
 {
   "run": "bash -c \"echo you should see this\"",
-  "iterations": 3
+  "iterations": 20
 }

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -177,7 +177,36 @@ fn iterations() {
             .as_sequence()
             .unwrap()
             .len()
-            == 3
+            == 20
+    });
+}
+
+#[test]
+#[serial]
+fn iterations_not_cumulative() {
+    json_has!("./examples/iterations.json", |map: &serde_yaml::Mapping| {
+        let iter = map
+            .get(&"iterations".into())
+            .unwrap()
+            .as_sequence()
+            .unwrap()
+            .iter();
+        let mut prev = 0.0;
+        for iteration in iter {
+            let val = iteration
+                .as_mapping()
+                .unwrap()
+                .get(&"user.time".into())
+                .unwrap()
+                .as_f64()
+                .unwrap();
+            if val < prev {
+                return true;
+            } else {
+                prev = val;
+            }
+        }
+        false
     });
 }
 


### PR DESCRIPTION
### What does this PR do?

Since `getrusage` give the cumulative resource usage for all subprocesses, we'd
get cumulative results up to that point for each iteration when using more than
one iteration. This fixes that by subtracting the sum of previous values from
the current value.

### Motivation

We ended up with always increasing values across iterations, which was
incorrect.

### Checklist

[x] I have added tests for the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
