### PR TITLE
Fix Rusage

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,10 +5,12 @@
 
 use anyhow::*;
 use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
 use serde_yaml::{from_str, Mapping, Value};
 use std::convert::{TryFrom, TryInto};
 use std::{collections::HashMap, env, fs::read_to_string};
 
+#[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct Config {
     pub(crate) name: Option<String>,
     pub(crate) variant: Option<String>,

--- a/src/rusage.rs
+++ b/src/rusage.rs
@@ -1,0 +1,47 @@
+use nix::libc::{getrusage, timeval, RUSAGE_CHILDREN};
+use std::mem::MaybeUninit;
+use std::ops::Sub;
+
+#[derive(Clone, Copy)]
+pub(crate) struct Rusage {
+    pub(crate) user_time: f64,
+    pub(crate) system_time: f64,
+    pub(crate) max_res_size: f64,
+}
+
+fn ms_from_timeval(tv: timeval) -> f64 {
+    let seconds = tv.tv_sec;
+    let ms = tv.tv_usec as i64;
+    let val = seconds * 1000000 + ms;
+    val as f64
+}
+
+impl Rusage {
+    pub fn new() -> Rusage {
+        let data = unsafe {
+            let mut data = MaybeUninit::zeroed().assume_init();
+            if getrusage(RUSAGE_CHILDREN, &mut data) == -1 {
+                panic!("getrusage is not working correctly");
+            }
+            data
+        };
+
+        Rusage {
+            user_time: ms_from_timeval(data.ru_utime) as f64,
+            system_time: ms_from_timeval(data.ru_stime) as f64,
+            max_res_size: data.ru_maxrss as f64,
+        }
+    }
+}
+
+impl Sub for Rusage {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self::Output {
+        Self {
+            user_time: self.user_time - other.user_time,
+            system_time: self.system_time - other.system_time,
+            max_res_size: self.max_res_size - other.max_res_size,
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

* fix utime and stime measuremeants by taking readings before and after test
* run iterations from sirun subprocesses

From the commit message for the 2nd item:

> `ru_maxrss` is not cumulative but a maximum among all subprocesses. This
> makes it relatively useless as soon as there's more than one subprocess.
> The workaround is to create a new subprocess for each iteration, each
> having its own single subprocess (i.e. the tested program itself). This
> way `ru_maxrss` can refer only to the one single subprocess.

### Motivation

We were finding that many of the metrics we were getting out of sirun when running multiple iterations were nonsensical.

### Checklist

[] I have added tests for the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
