### PR TITLE
add teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Create a JSON or YAML file with the following properties.
   availability of services, or retrieve some last-minute dependencies. This can
   be formatted the same way as `run`. It will be run repeatedly at 1 second
   intervals until it exits with status code 0.
+* **`teardown`**: A command to run _after_ the test. This is run in the same
+  manner as `setup`, except after the test has run instead of before.
 * **`timeout`**: If provided, this is the maximum time, in seconds, a `run` test
   can run for. If it times out, `sirun` will exit with no results, aborting the
   test.

--- a/examples/teardown.json
+++ b/examples/teardown.json
@@ -1,0 +1,4 @@
+{
+  "teardown": "echo a teardown was run",
+  "run": "echo the test was run"
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub(crate) struct Config {
     pub(crate) name: Option<String>,
     pub(crate) variant: Option<String>,
     pub(crate) setup: Option<Vec<String>>,
+    pub(crate) teardown: Option<Vec<String>>,
     pub(crate) run: Vec<String>,
     pub(crate) timeout: Option<u64>,
     pub(crate) env: HashMap<String, String>,
@@ -26,6 +27,7 @@ struct ProtoConfig {
     name: Option<String>,
     variant: Option<String>,
     setup: Option<Vec<String>>,
+    teardown: Option<Vec<String>>,
     run: Option<Vec<String>>,
     timeout: Option<u64>,
     env: HashMap<String, String>,
@@ -41,6 +43,7 @@ impl TryFrom<ProtoConfig> for Config {
             name: config.name,
             variant: config.variant,
             setup: config.setup,
+            teardown: config.teardown,
             run: match config.run {
                 Some(run) => run,
                 None => bail!("'run' must be provided"),
@@ -88,6 +91,7 @@ lazy_static! {
     static ref NAME_KEY: Value = "name".into();
     static ref RUN_KEY: Value = "run".into();
     static ref SETUP_KEY: Value = "setup".into();
+    static ref TEARDOWN_KEY: Value = "teardown".into();
     static ref TIMEOUT_KEY: Value = "timeout".into();
     static ref CACHEGRIND_KEY: Value = "cachegrind".into();
     static ref ITERATIONS_KEY: Value = "iterations".into();
@@ -115,6 +119,10 @@ fn apply_config(config: &mut ProtoConfig, config_val: &Value) -> Result<()> {
 
     if config_val.contains_key(&SETUP_KEY) {
         config.setup = Some(get_shell_command(config_val, &SETUP_KEY)?);
+    }
+
+    if config_val.contains_key(&TEARDOWN_KEY) {
+        config.teardown = Some(get_shell_command(config_val, &TEARDOWN_KEY)?);
     }
 
     if let Some(timeout_val) = config_val.get(&TIMEOUT_KEY) {
@@ -149,6 +157,7 @@ pub(crate) fn get_config(filename: &str) -> Result<Config> {
         name: None,
         variant: None,
         setup: None,
+        teardown: None,
         run: None,
         timeout: None,
         env: HashMap::new(),

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -93,6 +93,17 @@ fn no_setup() {
 
 #[test]
 #[serial]
+fn teardown() {
+    run!("examples/teardown.json")
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with(
+            "the test was run\na teardown was run",
+        ));
+}
+
+#[test]
+#[serial]
 fn variants() {
     run!("./examples/variants.json")
         .env("SIRUN_VARIANT", "0")


### PR DESCRIPTION
### What does this PR do?

Adds the "teardown" option, which is a script that runs after a test has
completed.

### Motivation

We're running into many cases where this would be helpful.

### Checklist

[x] I have added tests for the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
