### PR TITLE
Fix SSH URL for install on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ ensure you have the latest stable Rust toolchain enabled.
 
 #### Without cloning locally
 
-`cargo install --git git@github.com:DataDog/sirun.git`
+With SSH
+
+`cargo install --git ssh://git@github.com:22/DataDog/sirun.git --branch main`
+
+or with HTTPS
+
+`cargo install --git https://github.com/DataDog/sirun.git --branch main`
 
 ## Usage
 


### PR DESCRIPTION
### What does this PR do?

Fix the URL used for `cargo install --git` on README file.

### Motivation

Cargo cannot recognize the `git@github.com` as a valid URL by itself.

### Additional Notes

When you use a SSH url without protocol prefix, Cargo does not recognize
it as a valid URL. The error raised is `invalid url: relative URL
without a base`.

In addiction to the url prefix you have to specify the right remote-tracking
branch because `cargo --git` uses `origin/master` by default.
