### PR TITLE
Fix Startup and Teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Create a JSON or YAML file with the following properties.
 * **`env`**: A set of environment variables to make available to the `run` and
   `setup` programs. This should be an object whose keys are the environment
   variable names and whose values are the environment variable values.
-* **`iterations`**: The number of times to run the the `run` test. If this is
-  more than the default of 1, results for each iteration will be in an
-  `iterations` array in the resultant JSON.
+* **`iterations`**: The number of times to run the the `run` test. The results
+  for each iteration will be in an `iterations` array in the resultant JSON. The
+  default is 1.
 * **`cachegrind`**: If set to `true`, will run the test (after having already
   run it normally) using cachegrind to add an instruction count to the results
   JSON. Will only happen once, and be inserted into the top level JSON,
@@ -106,7 +106,7 @@ This will output something like the following.
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-{"version":"123abc","name":"test_some_stuff","user.time":6389.0,"system.time":8737.0,"udp.data":50.0,"max.res.size":2240512.0}
+{"version":"123abc","name":"test_some_stuff",iterations:[{"user.time":6389.0,"system.time":8737.0,"udp.data":50.0,"max.res.size":2240512.0}]}
 ```
 
 ## License

--- a/examples/iterations-nohup.json
+++ b/examples/iterations-nohup.json
@@ -1,0 +1,6 @@
+{
+  "setup": "bash -c \"nohup watch ls & echo $! > server.pid\"",
+  "run": "bash -c \"cat server.pid; ps aux | grep watch | grep ls; sleep 1\"",
+  "teardown": "bash -c \"echo killing; kill -9 `cat server.pid`; rm server.pid\"",
+  "iterations": 3
+}

--- a/src/metric_value.rs
+++ b/src/metric_value.rs
@@ -1,0 +1,38 @@
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Serialize, Clone)]
+#[serde(untagged)]
+pub(crate) enum MetricValue {
+    Str(String),
+    Num(f64),
+    Arr(Vec<HashMap<String, MetricValue>>),
+}
+
+impl MetricValue {
+    pub(crate) fn as_f64(self) -> f64 {
+        match self {
+            Self::Num(x) => x,
+            _ => panic!("not an f64"),
+        }
+    }
+}
+
+impl From<String> for MetricValue {
+    fn from(string: String) -> Self {
+        MetricValue::Str(string)
+    }
+}
+
+macro_rules! num_type {
+    ($type:ty) => {
+        impl From<$type> for MetricValue {
+            fn from(num: $type) -> Self {
+                MetricValue::Num(num as f64)
+            }
+        }
+    };
+}
+num_type!(i32);
+num_type!(i64);
+num_type!(f64);

--- a/src/statsd.rs
+++ b/src/statsd.rs
@@ -1,0 +1,47 @@
+use crate::metric_value::*;
+use anyhow::*;
+use async_std::{
+    net::UdpSocket,
+    sync::{Arc, Barrier, RwLock},
+};
+use std::collections::HashMap;
+
+pub(crate) async fn statsd_listener(
+    barrier: Arc<Barrier>,
+    statsd_buf: Arc<RwLock<String>>,
+) -> Result<()> {
+    let socket = UdpSocket::bind("127.0.0.1:8125").await;
+    let socket = match socket {
+        Ok(s) => s,
+        Err(error) => panic!("Cannot bind to 127.0.0.1:8125: {}", error),
+    };
+    barrier.wait().await; // indicates to main task that socket is listening
+
+    loop {
+        let mut buf = vec![0u8; 4096];
+        let (recv, _peer) = socket.recv_from(&mut buf).await?;
+
+        let datum = String::from_utf8(buf[..recv].into()).unwrap_or_else(|_| String::new());
+        statsd_buf.write().await.push_str(&datum);
+    }
+}
+
+pub(crate) async fn get_statsd_metrics(
+    udp_data: Arc<RwLock<String>>,
+) -> Result<HashMap<String, MetricValue>> {
+    let mut metrics = HashMap::new();
+    let udp_string = udp_data.read().await.clone();
+    let lines = udp_string.trim().lines();
+    udp_data.write().await.clear();
+    for line in lines {
+        let metric: Vec<&str> = match line.split('|').next() {
+            None => continue,
+            Some(metric) => metric.split(':').collect(),
+        };
+        if metric.len() < 2 {
+            continue;
+        }
+        metrics.insert(metric[0].into(), metric[1].parse::<f64>()?.into());
+    }
+    Ok(metrics)
+}

--- a/src/subproc.rs
+++ b/src/subproc.rs
@@ -1,0 +1,72 @@
+use anyhow::*;
+use async_std::{
+    process::{Command, ExitStatus, Stdio},
+    task::sleep,
+};
+use std::{collections::HashMap, env, time::Duration};
+
+use crate::config::*;
+
+async fn run_setup_or_teardown(typ: &str, config: &Config) -> Result<()> {
+    if env::var("SIRUN_SKIP_SETUP").is_ok() {
+        return Ok(());
+    }
+    let command_arr = if typ == "setup" {
+        &config.setup
+    } else {
+        &config.teardown
+    };
+    let command_arr = match command_arr {
+        Some(command_arr) => command_arr,
+        None => return Ok(()),
+    };
+    let env = &config.env;
+    let mut code: i32 = 1;
+    let mut attempts: u8 = 0;
+    while code != 0 {
+        if attempts == 100 {
+            bail!("{} script did not complete successfully. aborting.", typ);
+        }
+        code = run_cmd(command_arr, env)
+            .await?
+            .code()
+            .expect("no exit code");
+        if code != 0 {
+            sleep(Duration::from_secs(1)).await;
+            attempts += 1;
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn run_setup(config: &Config) -> Result<()> {
+    run_setup_or_teardown("setup", config).await
+}
+
+pub(crate) async fn run_teardown(config: &Config) -> Result<()> {
+    run_setup_or_teardown("teardown", config).await
+}
+
+fn get_stdio() -> Stdio {
+    match env::var("SIRUN_NO_STDIO") {
+        Ok(_) => Stdio::null(),
+        Err(_) => Stdio::inherit(),
+    }
+}
+
+pub(crate) async fn run_cmd(
+    command_arr: &Vec<String>,
+    env: &HashMap<String, String>,
+) -> Result<ExitStatus> {
+    let command = command_arr[0].clone();
+    let args = command_arr.iter().skip(1);
+    Command::new(command)
+        .args(args)
+        .envs(env.clone())
+        .stdout(get_stdio())
+        .stderr(get_stdio())
+        .status()
+        .await
+        .map_err(|e| e.into())
+}

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -37,7 +37,12 @@ fn simple_json() {
 #[serial]
 fn wall_and_cpu_pct() {
     json_has!("examples/simple.json", move |map: &serde_yaml::Mapping| {
-        let map = map;
+        let map = map
+            .get(&"iterations".into())
+            .unwrap()
+            .as_sequence()
+            .unwrap();
+        let map = map.get(0).unwrap().as_mapping().unwrap();
         let wall_time = map.get(&"wall.time".into()).unwrap().as_f64().unwrap();
         let stime = map.get(&"system.time".into()).unwrap().as_f64().unwrap();
         let utime = map.get(&"user.time".into()).unwrap().as_f64().unwrap();
@@ -194,6 +199,12 @@ fn iterations() {
 
 #[test]
 #[serial]
+fn iterations_nohup() {
+    run!("./examples/iterations-nohup.json").assert().success();
+}
+
+#[test]
+#[serial]
 fn iterations_not_cumulative() {
     json_has!("./examples/iterations.json", |map: &serde_yaml::Mapping| {
         let iter = map
@@ -225,6 +236,16 @@ fn iterations_not_cumulative() {
 #[serial]
 fn long() {
     json_has!("./examples/long.json", |map: &serde_yaml::Mapping| {
-        map.get(&"user.time".into()).unwrap().as_f64().unwrap() > 1000000.0
+        map.get(&"iterations".into())
+            .unwrap()
+            .get(0)
+            .unwrap()
+            .as_mapping()
+            .unwrap()
+            .get(&"user.time".into())
+            .unwrap()
+            .as_f64()
+            .unwrap()
+            > 1000000.0
     });
 }


### PR DESCRIPTION
### What does this PR do?
- fix startup and teardown
- refactor main.rs, splitting into multiple files

### Motivation

While attempting to use sirun with tests where the startup and teardown depended
on shared state, it seemed that it wasn't exactly one startup and one teardown
per iteration, and yet that's what was needed.
