### PR TITLE
fail silently when valgrind is not available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +769,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "shlex",
+ "which",
 ]
 
 [[package]]
@@ -933,6 +940,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "which"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
+dependencies = [
+ "either",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_yaml = "0.8.17"
 lazy_static = "1.4.0"
 serde = { version = "1.0.124", features = ["derive"] }
 anyhow = "1.0.38"
+which = "4.0.2"
 
 [dev-dependencies]
 predicates = "1.0.7"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,5 +1,6 @@
 Component,Origin,License,Copyright
 aho-corasick,https://github.com/BurntSushi/aho-corasick,MIT OR Unlicense,Andrew Gallant <jamslam@gmail.com>
+anyhow,https://github.com/dtolnay/anyhow,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
 assert_cmd,https://github.com/assert-rs/assert_cmd.git,Apache-2.0 OR MIT,Pascal Hertleif <killercup@gmail.com>|Ed Page <eopage@gmail.com>
 async-attributes,https://github.com/async-rs/async-attributes,Apache-2.0 OR MIT,Yoshua Wuyts <yoshuawuyts@gmail.com>
 async-channel,https://github.com/smol-rs/async-channel,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
@@ -28,6 +29,7 @@ ctor,https://github.com/mmastrac/rust-ctor,Apache-2.0 OR MIT,Matt Mastracci <mat
 difference,https://github.com/johannhof/difference.rs,MIT,Johann Hofmann <mail@johann-hofmann.com>
 doc-comment,https://github.com/GuillaumeGomez/doc-comment,MIT,Guillaume Gomez <guillaume1.gomez@gmail.com>
 dtoa,https://github.com/dtolnay/dtoa,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
+either,https://github.com/bluss/either,Apache-2.0 OR MIT,bluss
 event-listener,https://github.com/stjepang/event-listener,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 fastrand,https://github.com/stjepang/fastrand,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 float-cmp,https://github.com/mikedilger/float-cmp,MIT,Mike Dilger <mike@mikedilger.com>
@@ -71,6 +73,7 @@ regex-syntax,https://github.com/rust-lang/regex,Apache-2.0 OR MIT,The Rust Proje
 ryu,https://github.com/dtolnay/ryu,Apache-2.0 OR BSL-1.0,David Tolnay <dtolnay@gmail.com>
 scopeguard,https://github.com/bluss/scopeguard,Apache-2.0 OR MIT,bluss
 serde,https://github.com/serde-rs/serde,Apache-2.0 OR MIT,Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com>
+serde_derive,https://github.com/serde-rs/serde,Apache-2.0 OR MIT,Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com>
 serde_json,https://github.com/serde-rs/json,Apache-2.0 OR MIT,Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com>
 serde_yaml,https://github.com/dtolnay/serde-yaml,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
 serial_test,https://github.com/palfrey/serial_test/,MIT,Tom Parker-Shemilt <palfrey@tevp.net>
@@ -97,6 +100,7 @@ wasm-bindgen-macro-support,https://github.com/rustwasm/wasm-bindgen/tree/master/
 wasm-bindgen-shared,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared,Apache-2.0 OR MIT,The wasm-bindgen Developers
 web-sys,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys,Apache-2.0 OR MIT,The wasm-bindgen Developers
 wepoll-sys,https://gitlab.com/yorickpeterse/wepoll-sys,MPL-2.0,Yorick Peterse <yorickpeterse@gmail.com>
+which,https://github.com/harryfei/which-rs.git,MIT,Harry Fei <tiziyuanfang@gmail.com>
 winapi,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>
 winapi-i686-pc-windows-gnu,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>
 winapi-x86_64-pc-windows-gnu,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use async_std::{
 };
 use serde_json::json;
 use std::{collections::HashMap, env, process::exit};
+use which::which;
 
 mod config;
 use config::*;
@@ -102,7 +103,7 @@ async fn main_main() -> Result<()> {
     }
     metrics.insert("iterations".into(), MetricValue::Arr(iterations));
 
-    if config.cachegrind {
+    if config.cachegrind && which("valgrind").is_ok() {
         let command = "valgrind";
         let mut args = vec![
             "--tool=cachegrind".to_owned(),

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -168,14 +168,20 @@ fn stdio() {
         .stdout(predicate::str::contains("setup was run").not());
 }
 
-#[cfg(target_os = "linux")]
 #[test]
 #[serial]
 fn cachegrind() {
-    run!("./examples/cachegrind.json")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("\"instructions\":"));
+    if std::env::consts::OS == "linux" {
+        run!("./examples/cachegrind.json")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\"instructions\":"));
+    } else {
+        run!("./examples/cachegrind.json")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\"instructions\":").not());
+    }
 }
 
 #[test]


### PR DESCRIPTION
### What does this PR do?

Ignore `cachegrind: true` in config when valgrind isn't available.

### Motivation

There's no need to crash just because valgrind isn't available.

### Checklist

[x] I have added tests for the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
