### PR TITLE
pass SIRUN_ITERATION to setup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,11 +177,11 @@ async fn run_iteration(
     config: &Config,
     statsd_buf: Arc<RwLock<String>>,
 ) -> Result<HashMap<String, MetricValue>> {
-    run_setup(&config).await?;
-
     let mut sub_config: Config = config.clone();
     let json_config = serde_yaml::to_string(&config)?;
     sub_config.env.insert("SIRUN_ITERATION".into(), json_config);
+    run_setup(&sub_config).await?;
+
     let status = run_cmd(
         &env::args().take(1).collect::<Vec<String>>(),
         &sub_config.env,


### PR DESCRIPTION
### What does this PR do?

Passes `SIRUN_ITERATION` environment variable to the setup subprocess.

### Motivation

I want to know the sirun iteration when in the setup subprocess.

### Related issues

### Additional Notes

### Checklist

[] I have added tests for the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
