### PR TITLE
Fix for anyhow breaking Ok(...) patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ assert_cmd = "1.0.3"
 serde_yaml = "0.8.17"
 lazy_static = "1.4.0"
 serde = { version = "1.0.124", features = ["derive"] }
-anyhow = "1.0.38"
+anyhow = "<=1.0.48"
 which = "4.0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
anyhow after 1.0.48 breaks when using `use anyhow::*;` as it exports an `Ok(...)` function which replaces `Result::Ok`.

See: https://github.com/rust-math/intel-mkl-src/issues/68