### PR TITLE
Replace `ms` with `us` to represent microseconds

### DIFF
--- a/src/rusage.rs
+++ b/src/rusage.rs
@@ -9,10 +9,10 @@ pub(crate) struct Rusage {
     pub(crate) max_res_size: f64,
 }
 
-fn ms_from_timeval(tv: timeval) -> f64 {
+fn us_from_timeval(tv: timeval) -> f64 {
     let seconds = tv.tv_sec;
-    let ms = tv.tv_usec as i64;
-    let val = seconds * 1000000 + ms;
+    let us = tv.tv_usec as i64;
+    let val = seconds * 1000000 + us;
     val as f64
 }
 
@@ -27,8 +27,8 @@ impl Rusage {
         };
 
         Rusage {
-            user_time: ms_from_timeval(data.ru_utime) as f64,
-            system_time: ms_from_timeval(data.ru_stime) as f64,
+            user_time: us_from_timeval(data.ru_utime) as f64,
+            system_time: us_from_timeval(data.ru_stime) as f64,
             max_res_size: data.ru_maxrss as f64,
         }
     }


### PR DESCRIPTION
### What does this PR do?

Change a variable name

### Motivation

Commonly `ms` is used to represent milliseconds, while `us` (or `μs` though harder to type) is used to represent microsecond.

Dmytro caught this while analyzing the output to determine units.

Maybe `micros` would be better? `us` sounds like us / we.