### PR TITLE
add service process

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Create a JSON or YAML file with the following properties:
   intermediary process. Note that subprocesses will not be measured via the
   kernel, but they can still use Statsd. To send metrics to Statsd from inside
   this process, send them to `udp://localhost:$SIRUN_STATSD_PORT`.
+* **`service`**: A command to start a process to be run alongside your test
+  process. This is for, for example, running a web service for your program to
+  call out to, or a load-generating tool for your program. It should generally
+  be used in conjunction with `setup`, which can be used to determine whether
+  the `service` process is ready. There is no retry logic. After the test run
+  has completed, the process will be sent a SIGKILL.
 * **`setup`**: A command to run _before_ the test. Use this to ensure the
   availability of services, or retrieve some last-minute dependencies. This can
   be formatted the same way as `run`. It will be run repeatedly at 1 second

--- a/examples/service.json
+++ b/examples/service.json
@@ -1,5 +1,5 @@
 {
-  "service": "python -m http.server --bind 127.0.0.1",
+  "service": "python3 -m http.server --bind 127.0.0.1",
   "setup": "curl http://127.0.0.1:8000",
   "run": "curl http://127.0.0.1:8000",
   "iterations": 3

--- a/examples/service.json
+++ b/examples/service.json
@@ -1,6 +1,6 @@
 {
   "service": "python -m http.server",
-  "setup": "curl localhost:8000",
-  "run": "curl localhost:8000",
+  "setup": "curl http://[::]:8000",
+  "run": "curl http://[::]:8000",
   "iterations": 3
 }

--- a/examples/service.json
+++ b/examples/service.json
@@ -1,6 +1,6 @@
 {
-  "service": "python -m http.server",
-  "setup": "curl http://[::]:8000",
-  "run": "curl http://[::]:8000",
+  "service": "python -m http.server --bind 127.0.0.1",
+  "setup": "curl http://127.0.0.1:8000",
+  "run": "curl http://127.0.0.1:8000",
   "iterations": 3
 }

--- a/examples/service.json
+++ b/examples/service.json
@@ -1,0 +1,6 @@
+{
+  "service": "python -m http.server",
+  "setup": "curl localhost:8000",
+  "run": "curl localhost:8000",
+  "iterations": 3
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ use std::{collections::HashMap, env, fs::read_to_string};
 pub(crate) struct Config {
     pub(crate) name: Option<String>,
     pub(crate) variant: Option<String>,
+    pub(crate) service: Option<Vec<String>>,
     pub(crate) setup: Option<Vec<String>>,
     pub(crate) teardown: Option<Vec<String>>,
     pub(crate) run: Vec<String>,
@@ -35,6 +36,7 @@ impl fmt::Display for Config {
 struct ProtoConfig {
     name: Option<String>,
     variant: Option<String>,
+    service: Option<Vec<String>>,
     setup: Option<Vec<String>>,
     teardown: Option<Vec<String>>,
     run: Option<Vec<String>>,
@@ -53,6 +55,7 @@ impl TryFrom<ProtoConfig> for Config {
         Ok(Config {
             name: config.name,
             variant: config.variant,
+            service: config.service,
             setup: config.setup,
             teardown: config.teardown,
             run: match config.run {
@@ -103,6 +106,7 @@ fn get_env(env: &mut HashMap<String, String>, config_env: &Value) -> Result<()> 
 lazy_static! {
     static ref NAME_KEY: Value = "name".into();
     static ref RUN_KEY: Value = "run".into();
+    static ref SERVICE_KEY: Value = "service".into();
     static ref SETUP_KEY: Value = "setup".into();
     static ref TEARDOWN_KEY: Value = "teardown".into();
     static ref TIMEOUT_KEY: Value = "timeout".into();
@@ -125,6 +129,10 @@ fn apply_config(config: &mut ProtoConfig, config_val: &Value) -> Result<()> {
                 .ok_or_else(|| anyhow!("'name' must be a string"))?
                 .to_owned(),
         );
+    }
+
+    if config_val.contains_key(&SERVICE_KEY) {
+        config.service = Some(get_shell_command(config_val, &SERVICE_KEY)?);
     }
 
     if config_val.contains_key(&RUN_KEY) {
@@ -176,6 +184,7 @@ pub(crate) fn get_config(filename: &str) -> Result<Config> {
     let mut config = ProtoConfig {
         name: None,
         variant: None,
+        service: None,
         setup: None,
         teardown: None,
         run: None,

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -304,3 +304,9 @@ fn insctrution_counts() {
         });
     }
 }
+
+#[test]
+#[serial]
+fn service() {
+    run!("./examples/service.json").assert().success();
+}


### PR DESCRIPTION
### What does this PR do?

Adds the ability to run a process alongside test processes that is killed after the test has completed.

### Motivation

Without this, a complicated setup storing pids etc. is required.

### Related issues

#45

### Checklist

[x] I have added tests for the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
