### PR TITLE
Fix max.res.size unit of measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Here's an example of one of these lines of output, though whitespace has been ad
 - **`name`**: This is the same `name` value from the configuration file.
 - **`variant`**: This is the object key from the configuration file's `variations` list.
 - **`iterations`**: These are the statsd metrics from different runs and contain raw data
-  - **`max.res.size`**: Bytes (B) maximum Resident Set Size (RSS), aka the highest RAM usage
+  - **`max.res.size`**: Kilobytes (KiB) maximum Resident Set Size (RSS), aka the highest RAM usage
   - **`system.time`**: Microsecond (μs) amount of time spent in kernel code
   - **`user.time`**: Microsecond (μs) amount of time spent in application code
   - **`wall.time`**: Microsecond (μs) amount of time the overall iteration took


### PR DESCRIPTION
`max.res.size` is always reported in KiB, not in bytes, since Sirun uses ru_maxrss from getrusage under the hood.

In linux:
* https://linux.die.net/man/2/getrusage

In MacOs:
* https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getrusage.2.html

### What does this PR do?

Update UoM for `max.res.size`.

### Motivation

Fix misleading UoM description in README.

### Related issues

We observed 10^3 lower RSS usage reporting in PHP profiler and NodeJS GraphQL benchmarks. This led us to verification of UoM and we found that it is not bytes, but KiB that is reported.

### Checklist

[x] I have added tests for the code I am submitting
[x] My unit tests cover both failure and success scenarios
[x] If applicable, I have discussed my architecture
