### PR TITLE
remove cachegrind support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,6 @@ Create a JSON or YAML file with the following properties:
 * **`iterations`**: The number of times to run the the `run` test. The results
   for each iteration will be in an `iterations` array in the resultant JSON. The
   default is 1.
-* **`cachegrind`**: If set to `true`, will run the test (after having already
-  run it normally) using cachegrind to add an instruction count to the results
-  JSON. Will only happen once, and be inserted into the top level JSON,
-  regardless of `iterations`. This requires that `valgrind` is installed on your
-  system.
 * **`instructions`**: If set to `true`, will take instruction counts from
   hardware counters if available, adding the result under the key
   `instructions`, for each iteration. This is only available on Linux with

--- a/examples/cachegrind.json
+++ b/examples/cachegrind.json
@@ -1,4 +1,0 @@
-{
-  "run": "bash -c \"exit 0\"",
-  "cachegrind": true
-}

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,6 @@ pub(crate) struct Config {
     pub(crate) run: Vec<String>,
     pub(crate) timeout: Option<u64>,
     pub(crate) env: HashMap<String, String>,
-    pub(crate) cachegrind: bool,
     pub(crate) iterations: u64,
     pub(crate) instructions: bool,
     pub(crate) variants: Option<Vec<String>>,
@@ -70,7 +69,6 @@ lazy_static! {
     static ref SETUP_KEY: Value = "setup".into();
     static ref TEARDOWN_KEY: Value = "teardown".into();
     static ref TIMEOUT_KEY: Value = "timeout".into();
-    static ref CACHEGRIND_KEY: Value = "cachegrind".into();
     static ref ITERATIONS_KEY: Value = "iterations".into();
     static ref INSTRUCTIONS_KEY: Value = "instructions".into();
 }
@@ -115,12 +113,6 @@ fn apply_config(config: &mut Config, config_val: &Value) -> Result<()> {
         );
     }
 
-    if let Some(cachegrind_val) = config_val.get(&CACHEGRIND_KEY) {
-        config.cachegrind = cachegrind_val
-            .as_bool()
-            .ok_or_else(|| anyhow!("'cachegrind' must be a boolean"))?;
-    }
-
     if let Some(iterations_val) = config_val.get(&ITERATIONS_KEY) {
         config.iterations = iterations_val
             .as_u64()
@@ -150,7 +142,6 @@ pub(crate) fn get_config(filename: &str) -> Result<Config> {
         run: vec!["INIT".into()],
         timeout: None,
         env: HashMap::new(),
-        cachegrind: false,
         instructions: false,
         iterations: 1,
         variants: None,

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -180,22 +180,6 @@ fn stdio() {
 
 #[test]
 #[serial]
-fn cachegrind() {
-    if std::env::consts::OS == "linux" {
-        run!("./examples/cachegrind.json")
-            .assert()
-            .success()
-            .stdout(predicate::str::contains("\"instructions\":"));
-    } else {
-        run!("./examples/cachegrind.json")
-            .assert()
-            .success()
-            .stdout(predicate::str::contains("\"instructions\":").not());
-    }
-}
-
-#[test]
-#[serial]
 fn iterations() {
     run!("./examples/iterations.json")
         .assert()


### PR DESCRIPTION
It was only added because cachegrind was the easiest way to get numbers on Macs, where it's no longer even supported. It's also incredibly slow.