### PR TITLE
chore(deps): update dependencies, drop unmaintained serde_yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,27 +4,34 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.38"
+name = "anstyle"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "1.0.3"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2475b58cd94eb4f70159f4fd8844ba3b807532fe3131b3373fae060bbe30396"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
+ "anstyle",
  "bstr",
- "doc-comment",
+ "libc 0.2.186",
  "predicates",
  "predicates-core",
  "predicates-tree",
@@ -38,112 +45,134 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "async-channel"
-version = "1.6.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
 [[package]]
-name = "async-executor"
-version = "1.4.0"
+name = "async-channel"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
- "once_cell",
- "vec-arena",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-executor",
  "async-io",
- "async-mutex",
+ "async-lock",
  "blocking",
  "futures-lite",
- "num_cpus",
  "once_cell",
 ]
 
 [[package]]
 name = "async-io"
-version = "1.3.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
+ "autocfg",
+ "cfg-if",
  "concurrent-queue",
- "fastrand",
+ "futures-io",
  "futures-lite",
- "libc 0.2.137",
- "log",
- "nb-connect",
- "once_cell",
  "parking",
  "polling",
- "vec-arena",
- "waker-fn",
- "winapi",
+ "rustix",
+ "slab",
+ "windows-sys",
 ]
 
 [[package]]
 name = "async-lock"
-version = "2.3.0"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-process"
-version = "1.0.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef37b86e2fa961bae5a4d212708ea0154f904ce31d1a4a7f47e1bbc33a0c040b"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
- "blocking",
- "cfg-if 1.0.0",
- "event-listener",
- "futures-lite",
- "once_cell",
- "signal-hook",
- "winapi",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys",
 ]
 
 [[package]]
 name = "async-std"
-version = "1.9.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
 dependencies = [
  "async-attributes",
- "async-channel",
+ "async-channel 1.9.0",
  "async-global-executor",
  "async-io",
  "async-lock",
@@ -157,7 +186,6 @@ dependencies = [
  "kv-log-macro",
  "log",
  "memchr",
- "num_cpus",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -167,55 +195,59 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.0.3"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "atomic-waker"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bit_field"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blocking"
-version = "1.0.2"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-task",
- "atomic-waker",
- "fastrand",
+ "futures-io",
  "futures-lite",
- "once_cell",
+ "piper",
 ]
 
 [[package]]
 name = "bstr"
-version = "0.2.15"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
- "lazy_static",
  "memchr",
  "regex-automata",
  "serde",
@@ -223,125 +255,72 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
-
-[[package]]
-name = "byteorder"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
-
-[[package]]
-name = "cache-padded"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "caps"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
+checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
 dependencies = [
- "libc 0.2.137",
- "thiserror",
+ "libc 0.2.186",
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.67"
+name = "cfg-if"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg-if"
-version = "0.1.10"
+name = "cfg_aliases"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
- "cache-padded",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
- "lazy_static",
-]
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "csv"
-version = "1.1.6"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
- "bstr",
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.10"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.19"
+name = "difflib"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "dtoa"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "equivalent"
@@ -350,25 +329,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "event-listener"
-version = "2.5.1"
+name = "errno"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
-
-[[package]]
-name = "fastrand"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
- "instant",
+ "libc 0.2.186",
+ "windows-sys",
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.8.0"
+name = "event-listener"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
@@ -402,106 +409,105 @@ checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.3"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
  "futures-io",
- "memchr",
  "parking",
  "pin-project-lite",
- "waker-fn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if 1.0.0",
- "libc 0.2.137",
+ "cfg-if",
+ "libc 0.2.186",
  "wasi",
 ]
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
  "js-sys",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
-dependencies = [
- "libc 0.2.137",
-]
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.48"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -516,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -528,40 +534,45 @@ checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.4"
+name = "libyaml-rs"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 dependencies = [
- "cfg-if 1.0.0",
  "value-bag",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mmap"
@@ -574,25 +585,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "nb-connect"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
-dependencies = [
- "libc 0.2.137",
- "socket2",
-]
-
-[[package]]
 name = "nix"
-version = "0.20.0"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc 0.2.137",
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -613,40 +614,30 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc 0.2.137",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "parking"
-version = "2.0.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -655,13 +646,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
- "libc 0.2.137",
+ "libc 0.2.186",
  "redox_syscall",
  "smallvec",
  "winapi",
@@ -673,8 +664,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba1fd955270ca6f8bd8624ec0c4ee1a251dd3cc0cc18e1e2665ca8f5acb1501"
 dependencies = [
- "bitflags",
- "libc 0.2.137",
+ "bitflags 1.3.2",
+ "libc 0.2.186",
  "mmap",
  "nom",
  "x86",
@@ -706,7 +697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43f3220d96e0080cc9ea234978ccd80d904eafb17be31bb0f76daaea6493082"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -720,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -731,31 +722,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "polling"
-version = "2.0.2"
+name = "piper"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
- "cfg-if 0.1.10",
- "libc 0.2.137",
- "log",
- "wepoll-sys",
- "winapi",
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
-version = "1.0.7"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb433456c1a57cc93554dea3ce40b4c19c4057e41c55d4a0f3d84ea71c325aa"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
- "difference",
+ "anstyle",
+ "difflib",
  "float-cmp",
  "normalize-line-endings",
  "predicates-core",
@@ -764,18 +771,18 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.2"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.2"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f553275e5721409451eb85e15fd9a860a6e5ab4496eb215987502b5f5391f2"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
- "treeline",
+ "termtree",
 ]
 
 [[package]]
@@ -803,7 +810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc 0.2.137",
+ "libc 0.2.186",
  "rand_core 0.3.1",
  "rdrand",
  "winapi",
@@ -811,11 +818,11 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc 0.2.137",
+ "libc 0.2.186",
  "rand_chacha",
  "rand_core 0.6.4",
 ]
@@ -856,11 +863,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "10.6.0"
+version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -874,39 +881,41 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-automata",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
- "byteorder",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "remove_dir_all"
@@ -918,59 +927,78 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.5"
+name = "rustix"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc 0.2.186",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap",
  "itoa",
- "ryu",
+ "memchr",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
-dependencies = [
- "dtoa",
- "linked-hash-map",
- "serde",
- "yaml-rust",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -992,93 +1020,82 @@ checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
-
-[[package]]
-name = "signal-hook"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7f3f92a1da3d6b1d32245d0cbcbbab0cfc45996d8df619c42bccfa6d2bbb5f"
-dependencies = [
- "libc 0.2.137",
- "signal-hook-registry",
-]
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "libc 0.2.137",
+ "errno",
+ "libc 0.2.186",
 ]
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "sirun"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "async-std",
  "caps",
- "indexmap 2.9.0",
- "lazy_static",
+ "indexmap",
  "nix",
  "perfcnt",
  "predicates",
  "serde",
  "serde_json",
- "serde_yaml",
  "serial_test",
  "shlex",
- "which",
+ "yaml_serde",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
-name = "socket2"
-version = "0.3.19"
+name = "syn"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "cfg-if 1.0.0",
- "libc 0.2.137",
- "winapi",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1092,39 +1109,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.37"
+name = "termtree"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "treeline"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "unicode-ident"
@@ -1133,25 +1121,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
 name = "value-bag"
-version = "1.0.0-alpha.6"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
-dependencies = [
- "ctor",
-]
-
-[[package]]
-name = "vec-arena"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "version_check"
@@ -1161,67 +1134,47 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
- "libc 0.2.137",
+ "libc 0.2.186",
 ]
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
-dependencies = [
- "bumpalo",
- "lazy_static",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.21"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
- "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1229,50 +1182,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
-
-[[package]]
-name = "web-sys"
-version = "0.3.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wepoll-sys"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "which"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
-dependencies = [
- "either",
- "libc 0.2.137",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1298,13 +1225,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "x86"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b5be8cc34d017d8aabec95bc45a43d0f20e8b2a31a453cabc804fe996f8dca"
 dependencies = [
  "bit_field",
- "bitflags",
+ "bitflags 1.3.2",
  "csv",
  "phf",
  "phf_codegen",
@@ -1313,10 +1255,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "yaml-rust"
-version = "0.4.5"
+name = "yaml_serde"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
 dependencies = [
- "linked-hash-map",
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sirun"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Bryan English <bryan.english@datadoghq.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
@@ -13,21 +13,21 @@ lto = true
 [dependencies]
 async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
-shlex = "1.0.0"
-nix = "0.20.0"
-assert_cmd = "1.0.3"
-serde_yaml = "0.8.17"
-lazy_static = "1.4.0"
-serde = { version = "1.0.124", features = ["derive"] }
-anyhow = "<=1.0.48"
-which = "4.0.2"
-indexmap = { version = "2.9.0", features = ["serde"] }
+shlex = "2.0.1"
+nix = { version = "0.31.3", features = ["fs"] }
+assert_cmd = "2.0.17"
+# yaml_serde is the official YAML organization's maintained fork of the
+# now-unmaintained serde_yaml; the package rename keeps `use serde_yaml::` working.
+serde_yaml = { package = "yaml_serde", version = "0.10" }
+serde = { version = "1.0.228", features = ["derive"] }
+anyhow = "1.0.102"
+indexmap = { version = "2.14.0", features = ["serde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 perfcnt = "0.8.0"
 
 [dev-dependencies]
-predicates = "1.0.7"
+predicates = "3.1.4"
 serial_test = "0.5.1"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,107 +1,139 @@
 Component,Origin,License,Copyright
 aho-corasick,https://github.com/BurntSushi/aho-corasick,MIT OR Unlicense,Andrew Gallant <jamslam@gmail.com>
+anstyle,https://github.com/rust-cli/anstyle.git,Apache-2.0 OR MIT,
 anyhow,https://github.com/dtolnay/anyhow,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
 assert_cmd,https://github.com/assert-rs/assert_cmd.git,Apache-2.0 OR MIT,Pascal Hertleif <killercup@gmail.com>|Ed Page <eopage@gmail.com>
 async-attributes,https://github.com/async-rs/async-attributes,Apache-2.0 OR MIT,Yoshua Wuyts <yoshuawuyts@gmail.com>
 async-channel,https://github.com/smol-rs/async-channel,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
-async-executor,https://github.com/stjepang/async-executor,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+async-channel,https://github.com/smol-rs/async-channel,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+async-executor,https://github.com/smol-rs/async-executor,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|John Nunley <dev@notgull.net>
 async-global-executor,https://github.com/Keruspe/async-global-executor,Apache-2.0 OR MIT,Marc-Antoine Perennou <Marc-Antoine@Perennou.com>
-async-io,https://github.com/stjepang/async-io,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
-async-lock,https://github.com/stjepang/async-lock,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
-async-mutex,https://github.com/stjepang/async-lock,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+async-io,https://github.com/smol-rs/async-io,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+async-lock,https://github.com/smol-rs/async-lock,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 async-process,https://github.com/smol-rs/async-process,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+async-signal,https://github.com/smol-rs/async-signal,Apache-2.0 OR MIT,John Nunley <dev@notgull.net>
 async-std,https://github.com/async-rs/async-std,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|Yoshua Wuyts <yoshuawuyts@gmail.com>|Friedel Ziegelmayer <me@dignifiedquire.com>|Contributors to async-std
-async-task,https://github.com/stjepang/async-task,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
-atomic-waker,https://github.com/stjepang/atomic-waker,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+async-task,https://github.com/smol-rs/async-task,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+atomic-waker,https://github.com/smol-rs/atomic-waker,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|Contributors to futures-rs
 autocfg,https://github.com/cuviper/autocfg,Apache-2.0 OR MIT,Josh Stone <cuviper@gmail.com>
+bit_field,https://github.com/phil-opp/rust-bit-field,Apache-2.0 OR MIT,Philipp Oppermann <dev@phil-opp.com>
 bitflags,https://github.com/bitflags/bitflags,Apache-2.0 OR MIT,The Rust Project Developers
-blocking,https://github.com/stjepang/blocking,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+bitflags,https://github.com/bitflags/bitflags,Apache-2.0 OR MIT,The Rust Project Developers
+blocking,https://github.com/smol-rs/blocking,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 bstr,https://github.com/BurntSushi/bstr,Apache-2.0 OR MIT,Andrew Gallant <jamslam@gmail.com>
 bumpalo,https://github.com/fitzgen/bumpalo,Apache-2.0 OR MIT,Nick Fitzgerald <fitzgen@gmail.com>
-byteorder,https://github.com/BurntSushi/byteorder,MIT OR Unlicense,Andrew Gallant <jamslam@gmail.com>
-cache-padded,https://github.com/stjepang/cache-padded,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
-cc,https://github.com/alexcrichton/cc-rs,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-cfg-if,https://github.com/alexcrichton/cfg-if,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-cfg-if,https://github.com/alexcrichton/cfg-if,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-concurrent-queue,https://github.com/stjepang/concurrent-queue,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
-crossbeam-utils,https://github.com/crossbeam-rs/crossbeam,Apache-2.0 OR MIT,The Crossbeam Project Developers
-ctor,https://github.com/mmastrac/rust-ctor,Apache-2.0 OR MIT,Matt Mastracci <matthew@mastracci.com>
-difference,https://github.com/johannhof/difference.rs,MIT,Johann Hofmann <mail@johann-hofmann.com>
-doc-comment,https://github.com/GuillaumeGomez/doc-comment,MIT,Guillaume Gomez <guillaume1.gomez@gmail.com>
-dtoa,https://github.com/dtolnay/dtoa,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
-either,https://github.com/bluss/either,Apache-2.0 OR MIT,bluss
-event-listener,https://github.com/stjepang/event-listener,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
-fastrand,https://github.com/stjepang/fastrand,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+caps,https://github.com/lucab/caps-rs,Apache-2.0 OR MIT,Luca Bruno <lucab@lucabruno.net>
+cfg-if,https://github.com/rust-lang/cfg-if,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
+cfg_aliases,https://github.com/katharostech/cfg_aliases,MIT,Zicklag <zicklag@katharostech.com>
+concurrent-queue,https://github.com/smol-rs/concurrent-queue,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|Taiki Endo <te316e89@gmail.com>|John Nunley <dev@notgull.net>
+crossbeam-utils,https://github.com/crossbeam-rs/crossbeam,Apache-2.0 OR MIT,
+csv,https://github.com/BurntSushi/rust-csv,MIT OR Unlicense,Andrew Gallant <jamslam@gmail.com>
+csv-core,https://github.com/BurntSushi/rust-csv,MIT OR Unlicense,Andrew Gallant <jamslam@gmail.com>
+difflib,https://github.com/DimaKudosh/difflib,MIT,Dima Kudosh <dimakudosh@gmail.com>
+equivalent,https://github.com/indexmap-rs/equivalent,Apache-2.0 OR MIT,
+errno,https://github.com/lambda-fairy/rust-errno,Apache-2.0 OR MIT,Chris Wong <lambda.fairy@gmail.com>|Dan Gohman <dev@sunfishcode.online>
+event-listener,https://github.com/smol-rs/event-listener,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+event-listener,https://github.com/smol-rs/event-listener,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|John Nunley <dev@notgull.net>
+event-listener-strategy,https://github.com/smol-rs/event-listener-strategy,Apache-2.0 OR MIT,John Nunley <dev@notgull.net>
+fastrand,https://github.com/smol-rs/fastrand,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 float-cmp,https://github.com/mikedilger/float-cmp,MIT,Mike Dilger <mike@mikedilger.com>
-futures-channel,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-futures-core,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-futures-io,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-futures-lite,https://github.com/stjepang/futures-lite,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|Contributors to futures-rs
+fuchsia-cprng,https://fuchsia.googlesource.com/fuchsia/+/master/garnet/public/rust/fuchsia-cprng,,Erick Tryzelaar <etryzelaar@google.com>
+futures-channel,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,
+futures-core,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,
+futures-io,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,
+futures-lite,https://github.com/smol-rs/futures-lite,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|Contributors to futures-rs
+futures-task,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,
+futures-util,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,
+getrandom,https://github.com/rust-random/getrandom,Apache-2.0 OR MIT,The Rand Project Developers
 gloo-timers,https://github.com/rustwasm/gloo/tree/master/crates/timers,Apache-2.0 OR MIT,Rust and WebAssembly Working Group
-hermit-abi,https://github.com/hermitcore/libhermit-rs,Apache-2.0 OR MIT,Stefan Lankes
+hashbrown,https://github.com/rust-lang/hashbrown,Apache-2.0 OR MIT,
+hermit-abi,https://github.com/hermit-os/hermit-rs,Apache-2.0 OR MIT,Stefan Lankes
+indexmap,https://github.com/indexmap-rs/indexmap,Apache-2.0 OR MIT,
 instant,https://github.com/sebcrozet/instant,BSD-3-Clause,sebcrozet <developer@crozet.re>
 itoa,https://github.com/dtolnay/itoa,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
-js-sys,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys,Apache-2.0 OR MIT,The wasm-bindgen Developers
+js-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys,Apache-2.0 OR MIT,The wasm-bindgen Developers
 kv-log-macro,https://github.com/yoshuawuyts/kv-log-macro,Apache-2.0 OR MIT,Yoshua Wuyts <yoshuawuyts@gmail.com>
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,Apache-2.0 OR MIT,Marvin Löbel <loebel.marvin@gmail.com>
 libc,https://github.com/rust-lang/libc,Apache-2.0 OR MIT,The Rust Project Developers
-linked-hash-map,https://github.com/contain-rs/linked-hash-map,Apache-2.0 OR MIT,Stepan Koltsov <stepan.koltsov@gmail.com>|Andrew Paseltiner <apaseltiner@gmail.com>
+libc,https://github.com/rust-lang/libc,Apache-2.0 OR MIT,The Rust Project Developers
+libyaml-rs,https://github.com/yaml/libyaml-rs,MIT,David Tolnay <dtolnay@gmail.com>|YAML Organization <noreply@yaml.org>
+linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT,Dan Gohman <dev@sunfishcode.online>
 lock_api,https://github.com/Amanieu/parking_lot,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
 log,https://github.com/rust-lang/log,Apache-2.0 OR MIT,The Rust Project Developers
-memchr,https://github.com/BurntSushi/rust-memchr,MIT OR Unlicense,Andrew Gallant <jamslam@gmail.com>|bluss
-nb-connect,https://github.com/smol-rs/nb-connect,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|Jayce Fayne <jayce.fayne@mailbox.org>
-nix,https://github.com/nix-rust/nix,MIT,The nix-rust Project Developers
+memchr,https://github.com/BurntSushi/memchr,MIT OR Unlicense,Andrew Gallant <jamslam@gmail.com>|bluss
+mmap,https://github.com/rbranson/rust-mmap,MIT,Rick Branson <rick@diodeware.com>|The Rust Project Developers
+nix,https://github.com/nix-rust/nix,MIT,
+nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 normalize-line-endings,https://github.com/derekdreery/normalize-line-endings,Apache-2.0,Richard Dodd <richdodj@gmail.com>
 num-traits,https://github.com/rust-num/num-traits,Apache-2.0 OR MIT,The Rust Project Developers
-num_cpus,https://github.com/seanmonstar/num_cpus,Apache-2.0 OR MIT,Sean McArthur <sean@seanmonstar.com>
 once_cell,https://github.com/matklad/once_cell,Apache-2.0 OR MIT,Aleksey Kladov <aleksey.kladov@gmail.com>
-parking,https://github.com/stjepang/parking,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|The Rust Project Developers
+parking,https://github.com/smol-rs/parking,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|The Rust Project Developers
 parking_lot,https://github.com/Amanieu/parking_lot,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
 parking_lot_core,https://github.com/Amanieu/parking_lot,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
-pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,Taiki Endo <te316e89@gmail.com>
+perfcnt,https://github.com/gz/rust-perfcnt,MIT,Gerd Zellweger <mail@gerdzellweger.com>|Brian Martin <bmartin@twitter.com>|Jens Breitbart <jbreitbart@gmail.com>|Marshall Pierce <marshall@mpierce.org>|Lucas Kent <rubickent@gmail.com>
+phf,https://github.com/sfackler/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
+phf_codegen,https://github.com/sfackler/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
+phf_generator,https://github.com/sfackler/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
+phf_shared,https://github.com/sfackler/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
+pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,
 pin-utils,https://github.com/rust-lang-nursery/pin-utils,Apache-2.0 OR MIT,Josef Brandl <mail@josefbrandl.de>
-polling,https://github.com/stjepang/polling,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+piper,https://github.com/smol-rs/piper,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|John Nunley <dev@notgull.net>
+polling,https://github.com/smol-rs/polling,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|John Nunley <dev@notgull.net>
+ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,Apache-2.0 OR MIT,The CryptoCorrosion Contributors
 predicates,https://github.com/assert-rs/predicates-rs,Apache-2.0 OR MIT,Nick Stevens <nick@bitcurry.com>
-predicates-core,https://github.com/assert-rs/predicates-rs/tree/master/predicates-core,Apache-2.0 OR MIT,Nick Stevens <nick@bitcurry.com>
-predicates-tree,https://github.com/assert-rs/predicates-rs/tree/master/predicates-tree,Apache-2.0 OR MIT,Nick Stevens <nick@bitcurry.com>
-proc-macro2,https://github.com/alexcrichton/proc-macro2,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>|David Tolnay <dtolnay@gmail.com>
+predicates-core,https://github.com/assert-rs/predicates-rs,Apache-2.0 OR MIT,
+predicates-tree,https://github.com/assert-rs/predicates-rs,Apache-2.0 OR MIT,
+proc-macro2,https://github.com/dtolnay/proc-macro2,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>|Alex Crichton <alex@alexcrichton.com>
 quote,https://github.com/dtolnay/quote,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
+rand,https://github.com/rust-lang-nursery/rand,Apache-2.0 OR MIT,The Rust Project Developers
+rand,https://github.com/rust-random/rand,Apache-2.0 OR MIT,The Rand Project Developers|The Rust Project Developers
+rand_chacha,https://github.com/rust-random/rand,Apache-2.0 OR MIT,The Rand Project Developers|The Rust Project Developers|The CryptoCorrosion Contributors
+rand_core,https://github.com/rust-random/rand,Apache-2.0 OR MIT,The Rand Project Developers|The Rust Project Developers
+rand_core,https://github.com/rust-random/rand,Apache-2.0 OR MIT,The Rand Project Developers|The Rust Project Developers
+rand_core,https://github.com/rust-random/rand,Apache-2.0 OR MIT,The Rand Project Developers|The Rust Project Developers
+raw-cpuid,https://github.com/gz/rust-cpuid,MIT,Gerd Zellweger <mail@gerdzellweger.com>
+rdrand,https://github.com/nagisa/rust_rdrand/,ISC,Simonas Kazlauskas <rdrand@kazlauskas.me>
 redox_syscall,https://gitlab.redox-os.org/redox-os/syscall,MIT,Jeremy Soller <jackpot51@gmail.com>
-regex,https://github.com/rust-lang/regex,Apache-2.0 OR MIT,The Rust Project Developers
-regex-automata,https://github.com/BurntSushi/regex-automata,MIT OR Unlicense,Andrew Gallant <jamslam@gmail.com>
-regex-syntax,https://github.com/rust-lang/regex,Apache-2.0 OR MIT,The Rust Project Developers
+regex,https://github.com/rust-lang/regex,Apache-2.0 OR MIT,The Rust Project Developers|Andrew Gallant <jamslam@gmail.com>
+regex-automata,https://github.com/rust-lang/regex,Apache-2.0 OR MIT,The Rust Project Developers|Andrew Gallant <jamslam@gmail.com>
+regex-syntax,https://github.com/rust-lang/regex,Apache-2.0 OR MIT,The Rust Project Developers|Andrew Gallant <jamslam@gmail.com>
+remove_dir_all,https://github.com/XAMPPRocky/remove_dir_all.git,Apache-2.0 OR MIT,Aaronepower <theaaronepower@gmail.com>
+rustix,https://github.com/bytecodealliance/rustix,Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT,Dan Gohman <dev@sunfishcode.online>|Jakub Konka <kubkon@jakubkonka.com>
+rustversion,https://github.com/dtolnay/rustversion,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
 ryu,https://github.com/dtolnay/ryu,Apache-2.0 OR BSL-1.0,David Tolnay <dtolnay@gmail.com>
 scopeguard,https://github.com/bluss/scopeguard,Apache-2.0 OR MIT,bluss
 serde,https://github.com/serde-rs/serde,Apache-2.0 OR MIT,Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com>
+serde_core,https://github.com/serde-rs/serde,Apache-2.0 OR MIT,Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com>
 serde_derive,https://github.com/serde-rs/serde,Apache-2.0 OR MIT,Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com>
 serde_json,https://github.com/serde-rs/json,Apache-2.0 OR MIT,Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com>
-serde_yaml,https://github.com/dtolnay/serde-yaml,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
 serial_test,https://github.com/palfrey/serial_test/,MIT,Tom Parker-Shemilt <palfrey@tevp.net>
 serial_test_derive,https://github.com/palfrey/serial_test/,MIT,Tom Parker-Shemilt <palfrey@tevp.net>
-shlex,https://github.com/comex/rust-shlex,Apache-2.0 OR MIT,comex <comexk@gmail.com>|Fenhl <fenhl@fenhl.net>
-signal-hook,https://github.com/vorner/signal-hook,Apache-2.0 OR MIT,Michal 'vorner' Vaner <vorner@vorner.cz>|Thomas Himmelstoss <thimm@posteo.de>
+shlex,https://github.com/comex/rust-shlex,Apache-2.0 OR MIT,comex <comexk@gmail.com>|Fenhl <fenhl@fenhl.net>|Adrian Taylor <adetaylor@chromium.org>|Alex Touchet <alextouchet@outlook.com>|Daniel Parks <dp+git@oxidized.org>|Garrett Berg <googberg@gmail.com>
 signal-hook-registry,https://github.com/vorner/signal-hook,Apache-2.0 OR MIT,Michal 'vorner' Vaner <vorner@vorner.cz>|Masaki Hara <ackie.h.gmai@gmail.com>
-slab,https://github.com/carllerche/slab,MIT,Carl Lerche <me@carllerche.com>
+siphasher,https://github.com/jedisct1/rust-siphash,Apache-2.0 OR MIT,Frank Denis <github@pureftpd.org>
+slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
 smallvec,https://github.com/servo/rust-smallvec,Apache-2.0 OR MIT,The Servo Project Developers
-socket2,https://github.com/alexcrichton/socket2-rs,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
 syn,https://github.com/dtolnay/syn,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
-thread_local,https://github.com/Amanieu/thread_local-rs,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
-treeline,https://github.com/softprops/treeline,MIT,softprops <d.tangren@gmail.com>
-unicode-xid,https://github.com/unicode-rs/unicode-xid,Apache-2.0 OR MIT,erick.tryzelaar <erick.tryzelaar@gmail.com>|kwantam <kwantam@gmail.com>
+syn,https://github.com/dtolnay/syn,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
+tempdir,https://github.com/rust-lang/tempdir,Apache-2.0 OR MIT,The Rust Project Developers
+termtree,https://github.com/rust-cli/termtree,MIT,
+unicode-ident,https://github.com/dtolnay/unicode-ident,(Apache-2.0 OR MIT) AND Unicode-3.0,David Tolnay <dtolnay@gmail.com>
 value-bag,https://github.com/sval-rs/value-bag,Apache-2.0 OR MIT,Ashley Mannix <ashleymannix@live.com.au>
-vec-arena,https://github.com/stjepang/vec-arena,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+version_check,https://github.com/SergioBenitez/version_check,Apache-2.0 OR MIT,Sergio Benitez <sb@sergio.bz>
 wait-timeout,https://github.com/alexcrichton/wait-timeout,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
-waker-fn,https://github.com/stjepang/waker-fn,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
-wasm-bindgen,https://github.com/rustwasm/wasm-bindgen,Apache-2.0 OR MIT,The wasm-bindgen Developers
-wasm-bindgen-backend,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend,Apache-2.0 OR MIT,The wasm-bindgen Developers
-wasm-bindgen-futures,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures,Apache-2.0 OR MIT,The wasm-bindgen Developers
-wasm-bindgen-macro,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro,Apache-2.0 OR MIT,The wasm-bindgen Developers
-wasm-bindgen-macro-support,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support,Apache-2.0 OR MIT,The wasm-bindgen Developers
-wasm-bindgen-shared,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared,Apache-2.0 OR MIT,The wasm-bindgen Developers
-web-sys,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys,Apache-2.0 OR MIT,The wasm-bindgen Developers
-wepoll-sys,https://gitlab.com/yorickpeterse/wepoll-sys,MPL-2.0,Yorick Peterse <yorickpeterse@gmail.com>
-which,https://github.com/harryfei/which-rs.git,MIT,Harry Fei <tiziyuanfang@gmail.com>
+wasi,https://github.com/bytecodealliance/wasi,Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT,The Cranelift Project Developers
+wasm-bindgen,https://github.com/wasm-bindgen/wasm-bindgen,Apache-2.0 OR MIT,The wasm-bindgen Developers
+wasm-bindgen-futures,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures,Apache-2.0 OR MIT,The wasm-bindgen Developers
+wasm-bindgen-macro,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro,Apache-2.0 OR MIT,The wasm-bindgen Developers
+wasm-bindgen-macro-support,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support,Apache-2.0 OR MIT,The wasm-bindgen Developers
+wasm-bindgen-shared,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared,Apache-2.0 OR MIT,The wasm-bindgen Developers
 winapi,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>
 winapi-i686-pc-windows-gnu,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>
 winapi-x86_64-pc-windows-gnu,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>
-yaml-rust,https://github.com/chyh1990/yaml-rust,Apache-2.0 OR MIT,Yuheng Chen <yuhengchen@sensetime.com>
+windows-link,https://github.com/microsoft/windows-rs,Apache-2.0 OR MIT,
+windows-sys,https://github.com/microsoft/windows-rs,Apache-2.0 OR MIT,
+x86,https://github.com/gz/rust-x86,MIT,Gerd Zellweger <mail@gerdzellweger.com>|Eric Kidd <git@randomhacks.net>|Philipp Oppermann <dev@phil-opp.com>|Dan Schatzberg <schatzberg.dan@gmail.com>|John Ericson <John_Ericson@Yahoo.com>|Rex Lunae <rexlunae@gmail.com>|Brian Martin <bmartin@twitter.com>|Caleb Boylan <calebboylan@gmail.com>|Nikolay Edigaryev <edigaryev@gmail.com>|Stefan Lankes <stlankes@eonerc.rwth-aachen.de>|Jonathan Klimt <jonathan.klimt@rwth-aachen.de>|Jens Breitbart <jbreitbart@gmail.com>|Reto Achermann <achreto@gmail.com>|woppopo <woppopo@protonmail.com>|Vikram Narayanan <vikram186@gmail.com>|Dan Cross <cross@gajendra.net>|Yuekai Jia <equation618@gmail.com>|Lucas Kent <rubickent@gmail.com>
+yaml_serde,https://github.com/yaml/yaml-serde,Apache-2.0 OR MIT,YAML Organization <noreply@yaml.org>
+zerocopy,https://github.com/google/zerocopy,Apache-2.0 OR BSD-2-Clause OR MIT,Joshua Liebow-Feeser <joshlf@google.com>|Jack Wrenn <jswrenn@amazon.com>
+zerocopy-derive,https://github.com/google/zerocopy,Apache-2.0 OR BSD-2-Clause OR MIT,Joshua Liebow-Feeser <joshlf@google.com>|Jack Wrenn <jswrenn@amazon.com>
+zmij,https://github.com/dtolnay/zmij,MIT,David Tolnay <dtolnay@gmail.com>

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,8 +3,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
-use anyhow::*;
-use lazy_static::lazy_static;
+use anyhow::{anyhow, bail, ensure, Result};
 use serde::{Deserialize, Serialize};
 use serde_yaml::{from_str, to_string, Mapping, Value};
 use std::fmt;
@@ -31,19 +30,15 @@ impl fmt::Display for Config {
     }
 }
 
-fn get_shell_command(obj: &Mapping, name: &Value) -> Result<Vec<String>> {
+fn get_shell_command(obj: &Mapping, name: &str) -> Result<Vec<String>> {
     let run = obj
         .get(name)
         .unwrap()
         .as_str()
-        .ok_or_else(|| anyhow!("'{}' must be a string", name.as_str().unwrap()))?;
+        .ok_or_else(|| anyhow!("'{}' must be a string", name))?;
 
-    shlex::split(run).ok_or_else(|| {
-        anyhow!(
-            "'{}' must be a properly formed shell command",
-            name.as_str().unwrap()
-        )
-    })
+    shlex::split(run)
+        .ok_or_else(|| anyhow!("'{}' must be a properly formed shell command", name))
 }
 
 fn get_env(env: &mut HashMap<String, String>, config_env: &Value) -> Result<()> {
@@ -62,17 +57,6 @@ fn get_env(env: &mut HashMap<String, String>, config_env: &Value) -> Result<()> 
     Ok(())
 }
 
-lazy_static! {
-    static ref NAME_KEY: Value = "name".into();
-    static ref RUN_KEY: Value = "run".into();
-    static ref SERVICE_KEY: Value = "service".into();
-    static ref SETUP_KEY: Value = "setup".into();
-    static ref TEARDOWN_KEY: Value = "teardown".into();
-    static ref TIMEOUT_KEY: Value = "timeout".into();
-    static ref ITERATIONS_KEY: Value = "iterations".into();
-    static ref INSTRUCTIONS_KEY: Value = "instructions".into();
-}
-
 fn apply_config(config: &mut Config, config_val: &Value) -> Result<()> {
     let config_val = config_val
         .as_mapping()
@@ -80,7 +64,7 @@ fn apply_config(config: &mut Config, config_val: &Value) -> Result<()> {
 
     if let Ok(name) = env::var("SIRUN_NAME") {
         config.name = Some(name)
-    } else if let Some(name_val) = config_val.get(&NAME_KEY) {
+    } else if let Some(name_val) = config_val.get("name") {
         config.name = Some(
             name_val
                 .as_str()
@@ -89,23 +73,23 @@ fn apply_config(config: &mut Config, config_val: &Value) -> Result<()> {
         );
     }
 
-    if config_val.contains_key(&SERVICE_KEY) {
-        config.service = Some(get_shell_command(config_val, &SERVICE_KEY)?);
+    if config_val.contains_key("service") {
+        config.service = Some(get_shell_command(config_val, "service")?);
     }
 
-    if config_val.contains_key(&RUN_KEY) {
-        config.run = get_shell_command(config_val, &RUN_KEY)?;
+    if config_val.contains_key("run") {
+        config.run = get_shell_command(config_val, "run")?;
     }
 
-    if config_val.contains_key(&SETUP_KEY) {
-        config.setup = Some(get_shell_command(config_val, &SETUP_KEY)?);
+    if config_val.contains_key("setup") {
+        config.setup = Some(get_shell_command(config_val, "setup")?);
     }
 
-    if config_val.contains_key(&TEARDOWN_KEY) {
-        config.teardown = Some(get_shell_command(config_val, &TEARDOWN_KEY)?);
+    if config_val.contains_key("teardown") {
+        config.teardown = Some(get_shell_command(config_val, "teardown")?);
     }
 
-    if let Some(timeout_val) = config_val.get(&TIMEOUT_KEY) {
+    if let Some(timeout_val) = config_val.get("timeout") {
         config.timeout = Some(
             timeout_val
                 .as_u64()
@@ -113,21 +97,21 @@ fn apply_config(config: &mut Config, config_val: &Value) -> Result<()> {
         );
     }
 
-    if let Some(iterations_val) = config_val.get(&ITERATIONS_KEY) {
+    if let Some(iterations_val) = config_val.get("iterations") {
         config.iterations = iterations_val
             .as_u64()
             .ok_or_else(|| anyhow!("iterations must be an integer >=1"))?;
         ensure!(config.iterations > 0, "iterations must be an integer >=1");
     }
 
-    if let Some(instructions_val) = config_val.get(&INSTRUCTIONS_KEY) {
+    if let Some(instructions_val) = config_val.get("instructions") {
         config.instructions = instructions_val
             .as_bool()
             .ok_or_else(|| anyhow!("'instructions' must be a boolean"))?;
     }
 
-    if let Some(env) = config_val.get(&"env".to_owned().into()) {
-        get_env(&mut config.env, &env)?;
+    if let Some(env) = config_val.get("env") {
+        get_env(&mut config.env, env)?;
     }
     Ok(())
 }
@@ -183,7 +167,7 @@ pub(crate) fn get_config(filename: &str) -> Result<Config> {
             );
             &variants[id]
         } else if let Some(variants) = variants.as_mapping() {
-            match variants.get(&variant_key.clone().into()) {
+            match variants.get(variant_key.as_str()) {
                 Some(val) => val,
                 None => bail!("variant key {} does not exist in object", variant_key),
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
-use anyhow::*;
+use anyhow::Result;
 use async_std::{
     net::UdpSocket,
     process::{Command, Stdio, Child, ExitStatus},
@@ -14,10 +14,9 @@ use serde_json::json;
 use std::{
     collections::HashMap,
     env,
-    os::unix::{io::{FromRawFd, RawFd}, process::ExitStatusExt},
+    os::unix::{io::{AsRawFd, FromRawFd, IntoRawFd, RawFd}, process::ExitStatusExt},
     process::exit,
 };
-use which::which;
 use indexmap::IndexMap;
 
 mod config;
@@ -139,16 +138,17 @@ async fn run_test(config: &Config, mut metrics: &mut HashMap<String, MetricValue
     let (read_fd, write_fd) = nix::unistd::pipe()?;
     // Set CLOEXEC on read_fd so the child does not inherit the read end.
     nix::fcntl::fcntl(
-        read_fd,
+        &read_fd,
         nix::fcntl::FcntlArg::F_SETFD(nix::fcntl::FdFlag::FD_CLOEXEC),
     )?;
+    let read_fd = read_fd.into_raw_fd();
 
     let mut start_time = std::time::Instant::now();
     // RUSAGE_CHILDREN cannot be snapshotted mid-run (it only updates after a child
     // exits), so we use read_child_cpu_us to snapshot the live process CPU at
     // signal time and subtract it from the final RUSAGE_CHILDREN delta.
     let rusage_start = Rusage::new();
-    let mut child = run_cmd(&config.run, &config.env, Some(write_fd))?;
+    let mut child = run_cmd(&config.run, &config.env, Some(write_fd.as_raw_fd()))?;
     // Close parent's write end so the child's exit causes EOF on the read end.
     nix::unistd::close(write_fd)?;
 

--- a/src/statsd.rs
+++ b/src/statsd.rs
@@ -1,5 +1,5 @@
 use crate::metric_value::*;
-use anyhow::*;
+use anyhow::Result;
 use async_std::{
     net::UdpSocket,
     sync::{Arc, Barrier, RwLock},

--- a/src/subproc.rs
+++ b/src/subproc.rs
@@ -1,4 +1,4 @@
-use anyhow::*;
+use anyhow::{bail, Result};
 use async_std::{
     process::{Command, Child, Stdio},
     task::sleep,

--- a/src/summarize.rs
+++ b/src/summarize.rs
@@ -3,7 +3,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
-use anyhow::*;
+use anyhow::Result;
 use async_std::io;
 use indexmap::IndexMap;
 

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -39,16 +39,16 @@ fn simple_json() {
 fn wall_and_cpu_pct() {
     json_has!("examples/simple.json", move |map: &serde_yaml::Mapping| {
         let map = map
-            .get(&"iterations".into())
+            .get("iterations")
             .unwrap()
             .as_sequence()
             .unwrap();
         let map = map.get(0).unwrap().as_mapping().unwrap();
-        let wall_time = map.get(&"wall.time".into()).unwrap().as_f64().unwrap();
-        let stime = map.get(&"system.time".into()).unwrap().as_f64().unwrap();
-        let utime = map.get(&"user.time".into()).unwrap().as_f64().unwrap();
+        let wall_time = map.get("wall.time").unwrap().as_f64().unwrap();
+        let stime = map.get("system.time").unwrap().as_f64().unwrap();
+        let utime = map.get("user.time").unwrap().as_f64().unwrap();
         let pct = map
-            .get(&"cpu.pct.wall.time".into())
+            .get("cpu.pct.wall.time")
             .unwrap()
             .as_f64()
             .unwrap();
@@ -188,7 +188,7 @@ fn iterations() {
             "you should see this\nyou should see this\nyou should see this",
         ));
     json_has!("./examples/iterations.json", |map: &serde_yaml::Mapping| {
-        map.get(&"iterations".into())
+        map.get("iterations")
             .unwrap()
             .as_sequence()
             .unwrap()
@@ -208,7 +208,7 @@ fn iterations_nohup() {
 fn iterations_not_cumulative() {
     json_has!("./examples/iterations.json", |map: &serde_yaml::Mapping| {
         let iter = map
-            .get(&"iterations".into())
+            .get("iterations")
             .unwrap()
             .as_sequence()
             .unwrap()
@@ -218,7 +218,7 @@ fn iterations_not_cumulative() {
             let val = iteration
                 .as_mapping()
                 .unwrap()
-                .get(&"user.time".into())
+                .get("user.time")
                 .unwrap()
                 .as_f64()
                 .unwrap();
@@ -236,13 +236,13 @@ fn iterations_not_cumulative() {
 #[serial]
 fn long() {
     json_has!("./examples/long.json", |map: &serde_yaml::Mapping| {
-        map.get(&"iterations".into())
+        map.get("iterations")
             .unwrap()
             .get(0)
             .unwrap()
             .as_mapping()
             .unwrap()
-            .get(&"user.time".into())
+            .get("user.time")
             .unwrap()
             .as_f64()
             .unwrap()
@@ -283,7 +283,7 @@ fn assigned_port() {
 fn insctrution_counts() {
     if caps::has_cap(None, caps::CapSet::Permitted, caps::Capability::CAP_SYS_PTRACE).unwrap() {
         json_has!("./examples/instructions.json", move |map: &serde_yaml::Mapping| {
-            let count = map.get(&"instructions".into())
+            let count = map.get("instructions")
                 .unwrap()
                 .as_f64()
                 .unwrap();
@@ -305,13 +305,13 @@ fn ready_signal_resets_wall_time() {
         "./examples/ready-signal.json",
         |map: &serde_yaml::Mapping| {
             let wall_time = map
-                .get(&"iterations".into())
+                .get("iterations")
                 .unwrap()
                 .as_sequence()
                 .unwrap()[0]
                 .as_mapping()
                 .unwrap()
-                .get(&"wall.time".into())
+                .get("wall.time")
                 .unwrap()
                 .as_f64()
                 .unwrap();
@@ -329,7 +329,7 @@ fn ready_signal_fallback_when_no_signal() {
     // App exits without writing to SIRUN_READY_FD — full timing used.
     json_has!("./examples/simple.json", |map: &serde_yaml::Mapping| {
         // simple.json has no ready signal; we just verify it still runs normally.
-        map.get(&"iterations".into())
+        map.get("iterations")
             .unwrap()
             .as_sequence()
             .unwrap()
@@ -345,14 +345,14 @@ fn ready_signal_cpu_pct_bounded() {
         "./examples/ready-signal-cpu.json",
         |map: &serde_yaml::Mapping| {
             let iter = map
-                .get(&"iterations".into())
+                .get("iterations")
                 .unwrap()
                 .as_sequence()
                 .unwrap()[0]
                 .as_mapping()
                 .unwrap();
             let cpu_pct = iter
-                .get(&"cpu.pct.wall.time".into())
+                .get("cpu.pct.wall.time")
                 .unwrap()
                 .as_f64()
                 .unwrap();


### PR DESCRIPTION
## Summary

Routine dependency refresh plus two changes that needed code, not just version bumps:

1. anyhow un-pinned from `<=1.0.48`. Past 1.0.51 the `use anyhow::*` globs import `anyhow::Ok`, which shadows `Result::Ok` in pattern position -- the breakage the pin worked around. Replaced with explicit imports.
2. serde_yaml is unmaintained/deprecated and the serde_yml fork is unsound (RUSTSEC-2025-0068). Moved to yaml_serde, the official YAML organization's fork, which also drops unmaintained unsafe-libyaml for libyaml-rs. Its &str-indexed Mapping API removed the need for the lazy_static Value keys, so lazy_static is gone too.

The rest is a full `cargo update` (serde, async-std, regex, libc, ...) plus major bumps for nix, assert_cmd, predicates, and shlex. LICENSE-3rdparty.csv regenerated to match.

## Drive-by

* Removed the unused `which` dependency and import (the long-standing build warning).

## Test plan

- [ ] `cargo test` on macOS and Ubuntu (21 example tests)
- [ ] `cargo clippy --all-targets`
- [ ] Linux-only paths (`perfcnt`, `caps`, getrusage/perf counters) build on the Ubuntu runner -- they can't compile on macOS

Refs: https://rustsec.org/advisories/RUSTSEC-2025-0068.html