### PR TITLE
fix: use dd-octo-sts for release workflow authentication

### DIFF
--- a/.github/chainguard/self.release.create-release.sts.yaml
+++ b/.github/chainguard/self.release.create-release.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/sirun:ref:refs/tags/v.*"
+
+claim_pattern:
+  event_name: "push"
+  job_workflow_ref: DataDog/sirun/\.github/workflows/release\.yml@refs/tags/v.*
+
+permissions:
+  contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,18 @@ on:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/sirun
+          policy: self.release.create-release
       - uses: actions/checkout@v2
       - uses: taiki-e/create-gh-release-action@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
   upload-assets:
     strategy:
       matrix:
@@ -22,7 +29,14 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
     runs-on: ${{ matrix.os || 'ubuntu-latest'}}
+    permissions:
+      id-token: write
     steps:
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/sirun
+          policy: self.release.create-release
       - uses: actions/checkout@v2
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
@@ -30,5 +44,5 @@ jobs:
           target: ${{ matrix.target }}
           archive: $bin-$tag-$target
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
           CARGO_PROFILE_RELEASE_LTO: true


### PR DESCRIPTION
## Summary

- The release workflow for v0.1.12 failed with `HTTP 403` because `GITHUB_TOKEN` write access is disabled org-wide
- Switched both `create-release` and `upload-assets` jobs to use `dd-octo-sts-action` to obtain a scoped token
- Added `.github/chainguard/self.release.create-release.sts.yaml` policy granting `contents: write` only to tag push events on this workflow

## Test plan

- [ ] Re-tag `v0.1.12` (or a new tag) and verify the release workflow completes successfully

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)