### PR TITLE
refactor(deps): migrate from discontinued async-std to smol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,27 +39,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,18 +65,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.4.1"
+name = "async-fs"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
  "async-lock",
  "blocking",
  "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -124,9 +99,20 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -135,14 +121,14 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-lite",
  "rustix",
 ]
@@ -163,34 +149,6 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -235,7 +193,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -252,12 +210,6 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
-
-[[package]]
-name = "bumpalo"
-version = "3.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "caps"
@@ -340,12 +292,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -361,7 +307,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -385,15 +331,6 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "futures-core"
@@ -421,24 +358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,18 +366,6 @@ dependencies = [
  "cfg-if",
  "libc 0.2.186",
  "wasi",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -501,26 +408,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "js-sys"
-version = "0.3.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
-dependencies = [
- "cfg-if",
- "futures-util",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,15 +444,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.4.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
-dependencies = [
- "value-bag",
 ]
 
 [[package]]
@@ -620,12 +498,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "parking"
@@ -714,12 +586,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -940,12 +806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,7 +911,6 @@ version = "0.1.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "async-std",
  "caps",
  "indexmap",
  "nix",
@@ -1061,6 +920,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "shlex",
+ "smol",
  "yaml_serde",
 ]
 
@@ -1075,6 +935,23 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
 
 [[package]]
 name = "syn"
@@ -1121,12 +998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
-
-[[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,61 +1017,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.123"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.123"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.123"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.123"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
-dependencies = [
- "unicode-ident",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 lto = true
 
 [dependencies]
-async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 shlex = "2.0.1"
 nix = { version = "0.31.3", features = ["fs"] }
@@ -22,6 +21,7 @@ serde_yaml = { package = "yaml_serde", version = "0.10" }
 serde = { version = "1.0.228", features = ["derive"] }
 anyhow = "1.0.102"
 indexmap = { version = "2.14.0", features = ["serde"] }
+smol = "2.0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 perfcnt = "0.8.0"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -3,16 +3,14 @@ aho-corasick,https://github.com/BurntSushi/aho-corasick,MIT OR Unlicense,Andrew 
 anstyle,https://github.com/rust-cli/anstyle.git,Apache-2.0 OR MIT,
 anyhow,https://github.com/dtolnay/anyhow,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
 assert_cmd,https://github.com/assert-rs/assert_cmd.git,Apache-2.0 OR MIT,Pascal Hertleif <killercup@gmail.com>|Ed Page <eopage@gmail.com>
-async-attributes,https://github.com/async-rs/async-attributes,Apache-2.0 OR MIT,Yoshua Wuyts <yoshuawuyts@gmail.com>
-async-channel,https://github.com/smol-rs/async-channel,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 async-channel,https://github.com/smol-rs/async-channel,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 async-executor,https://github.com/smol-rs/async-executor,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|John Nunley <dev@notgull.net>
-async-global-executor,https://github.com/Keruspe/async-global-executor,Apache-2.0 OR MIT,Marc-Antoine Perennou <Marc-Antoine@Perennou.com>
+async-fs,https://github.com/smol-rs/async-fs,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 async-io,https://github.com/smol-rs/async-io,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 async-lock,https://github.com/smol-rs/async-lock,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+async-net,https://github.com/smol-rs/async-net,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 async-process,https://github.com/smol-rs/async-process,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 async-signal,https://github.com/smol-rs/async-signal,Apache-2.0 OR MIT,John Nunley <dev@notgull.net>
-async-std,https://github.com/async-rs/async-std,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|Yoshua Wuyts <yoshuawuyts@gmail.com>|Friedel Ziegelmayer <me@dignifiedquire.com>|Contributors to async-std
 async-task,https://github.com/smol-rs/async-task,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 atomic-waker,https://github.com/smol-rs/atomic-waker,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|Contributors to futures-rs
 autocfg,https://github.com/cuviper/autocfg,Apache-2.0 OR MIT,Josh Stone <cuviper@gmail.com>
@@ -21,7 +19,6 @@ bitflags,https://github.com/bitflags/bitflags,Apache-2.0 OR MIT,The Rust Project
 bitflags,https://github.com/bitflags/bitflags,Apache-2.0 OR MIT,The Rust Project Developers
 blocking,https://github.com/smol-rs/blocking,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 bstr,https://github.com/BurntSushi/bstr,Apache-2.0 OR MIT,Andrew Gallant <jamslam@gmail.com>
-bumpalo,https://github.com/fitzgen/bumpalo,Apache-2.0 OR MIT,Nick Fitzgerald <fitzgen@gmail.com>
 caps,https://github.com/lucab/caps-rs,Apache-2.0 OR MIT,Luca Bruno <lucab@lucabruno.net>
 cfg-if,https://github.com/rust-lang/cfg-if,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
 cfg_aliases,https://github.com/katharostech/cfg_aliases,MIT,Zicklag <zicklag@katharostech.com>
@@ -32,41 +29,32 @@ csv-core,https://github.com/BurntSushi/rust-csv,MIT OR Unlicense,Andrew Gallant 
 difflib,https://github.com/DimaKudosh/difflib,MIT,Dima Kudosh <dimakudosh@gmail.com>
 equivalent,https://github.com/indexmap-rs/equivalent,Apache-2.0 OR MIT,
 errno,https://github.com/lambda-fairy/rust-errno,Apache-2.0 OR MIT,Chris Wong <lambda.fairy@gmail.com>|Dan Gohman <dev@sunfishcode.online>
-event-listener,https://github.com/smol-rs/event-listener,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 event-listener,https://github.com/smol-rs/event-listener,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|John Nunley <dev@notgull.net>
 event-listener-strategy,https://github.com/smol-rs/event-listener-strategy,Apache-2.0 OR MIT,John Nunley <dev@notgull.net>
 fastrand,https://github.com/smol-rs/fastrand,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 float-cmp,https://github.com/mikedilger/float-cmp,MIT,Mike Dilger <mike@mikedilger.com>
 fuchsia-cprng,https://fuchsia.googlesource.com/fuchsia/+/master/garnet/public/rust/fuchsia-cprng,,Erick Tryzelaar <etryzelaar@google.com>
-futures-channel,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,
 futures-core,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,
 futures-io,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,
 futures-lite,https://github.com/smol-rs/futures-lite,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|Contributors to futures-rs
-futures-task,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,
-futures-util,https://github.com/rust-lang/futures-rs,Apache-2.0 OR MIT,
 getrandom,https://github.com/rust-random/getrandom,Apache-2.0 OR MIT,The Rand Project Developers
-gloo-timers,https://github.com/rustwasm/gloo/tree/master/crates/timers,Apache-2.0 OR MIT,Rust and WebAssembly Working Group
 hashbrown,https://github.com/rust-lang/hashbrown,Apache-2.0 OR MIT,
 hermit-abi,https://github.com/hermit-os/hermit-rs,Apache-2.0 OR MIT,Stefan Lankes
 indexmap,https://github.com/indexmap-rs/indexmap,Apache-2.0 OR MIT,
 instant,https://github.com/sebcrozet/instant,BSD-3-Clause,sebcrozet <developer@crozet.re>
 itoa,https://github.com/dtolnay/itoa,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
-js-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys,Apache-2.0 OR MIT,The wasm-bindgen Developers
-kv-log-macro,https://github.com/yoshuawuyts/kv-log-macro,Apache-2.0 OR MIT,Yoshua Wuyts <yoshuawuyts@gmail.com>
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,Apache-2.0 OR MIT,Marvin Löbel <loebel.marvin@gmail.com>
 libc,https://github.com/rust-lang/libc,Apache-2.0 OR MIT,The Rust Project Developers
 libc,https://github.com/rust-lang/libc,Apache-2.0 OR MIT,The Rust Project Developers
 libyaml-rs,https://github.com/yaml/libyaml-rs,MIT,David Tolnay <dtolnay@gmail.com>|YAML Organization <noreply@yaml.org>
 linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT,Dan Gohman <dev@sunfishcode.online>
 lock_api,https://github.com/Amanieu/parking_lot,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
-log,https://github.com/rust-lang/log,Apache-2.0 OR MIT,The Rust Project Developers
 memchr,https://github.com/BurntSushi/memchr,MIT OR Unlicense,Andrew Gallant <jamslam@gmail.com>|bluss
 mmap,https://github.com/rbranson/rust-mmap,MIT,Rick Branson <rick@diodeware.com>|The Rust Project Developers
 nix,https://github.com/nix-rust/nix,MIT,
 nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 normalize-line-endings,https://github.com/derekdreery/normalize-line-endings,Apache-2.0,Richard Dodd <richdodj@gmail.com>
 num-traits,https://github.com/rust-num/num-traits,Apache-2.0 OR MIT,The Rust Project Developers
-once_cell,https://github.com/matklad/once_cell,Apache-2.0 OR MIT,Aleksey Kladov <aleksey.kladov@gmail.com>
 parking,https://github.com/smol-rs/parking,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|The Rust Project Developers
 parking_lot,https://github.com/Amanieu/parking_lot,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
 parking_lot_core,https://github.com/Amanieu/parking_lot,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
@@ -76,7 +64,6 @@ phf_codegen,https://github.com/sfackler/rust-phf,MIT,Steven Fackler <sfackler@gm
 phf_generator,https://github.com/sfackler/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
 phf_shared,https://github.com/sfackler/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
 pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,
-pin-utils,https://github.com/rust-lang-nursery/pin-utils,Apache-2.0 OR MIT,Josef Brandl <mail@josefbrandl.de>
 piper,https://github.com/smol-rs/piper,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|John Nunley <dev@notgull.net>
 polling,https://github.com/smol-rs/polling,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>|John Nunley <dev@notgull.net>
 ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,Apache-2.0 OR MIT,The CryptoCorrosion Contributors
@@ -99,7 +86,6 @@ regex-automata,https://github.com/rust-lang/regex,Apache-2.0 OR MIT,The Rust Pro
 regex-syntax,https://github.com/rust-lang/regex,Apache-2.0 OR MIT,The Rust Project Developers|Andrew Gallant <jamslam@gmail.com>
 remove_dir_all,https://github.com/XAMPPRocky/remove_dir_all.git,Apache-2.0 OR MIT,Aaronepower <theaaronepower@gmail.com>
 rustix,https://github.com/bytecodealliance/rustix,Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT,Dan Gohman <dev@sunfishcode.online>|Jakub Konka <kubkon@jakubkonka.com>
-rustversion,https://github.com/dtolnay/rustversion,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
 ryu,https://github.com/dtolnay/ryu,Apache-2.0 OR BSL-1.0,David Tolnay <dtolnay@gmail.com>
 scopeguard,https://github.com/bluss/scopeguard,Apache-2.0 OR MIT,bluss
 serde,https://github.com/serde-rs/serde,Apache-2.0 OR MIT,Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com>
@@ -113,20 +99,15 @@ signal-hook-registry,https://github.com/vorner/signal-hook,Apache-2.0 OR MIT,Mic
 siphasher,https://github.com/jedisct1/rust-siphash,Apache-2.0 OR MIT,Frank Denis <github@pureftpd.org>
 slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
 smallvec,https://github.com/servo/rust-smallvec,Apache-2.0 OR MIT,The Servo Project Developers
+smol,https://github.com/smol-rs/smol,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 syn,https://github.com/dtolnay/syn,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
 syn,https://github.com/dtolnay/syn,Apache-2.0 OR MIT,David Tolnay <dtolnay@gmail.com>
 tempdir,https://github.com/rust-lang/tempdir,Apache-2.0 OR MIT,The Rust Project Developers
 termtree,https://github.com/rust-cli/termtree,MIT,
 unicode-ident,https://github.com/dtolnay/unicode-ident,(Apache-2.0 OR MIT) AND Unicode-3.0,David Tolnay <dtolnay@gmail.com>
-value-bag,https://github.com/sval-rs/value-bag,Apache-2.0 OR MIT,Ashley Mannix <ashleymannix@live.com.au>
 version_check,https://github.com/SergioBenitez/version_check,Apache-2.0 OR MIT,Sergio Benitez <sb@sergio.bz>
 wait-timeout,https://github.com/alexcrichton/wait-timeout,Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
 wasi,https://github.com/bytecodealliance/wasi,Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT,The Cranelift Project Developers
-wasm-bindgen,https://github.com/wasm-bindgen/wasm-bindgen,Apache-2.0 OR MIT,The wasm-bindgen Developers
-wasm-bindgen-futures,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures,Apache-2.0 OR MIT,The wasm-bindgen Developers
-wasm-bindgen-macro,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro,Apache-2.0 OR MIT,The wasm-bindgen Developers
-wasm-bindgen-macro-support,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support,Apache-2.0 OR MIT,The wasm-bindgen Developers
-wasm-bindgen-shared,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared,Apache-2.0 OR MIT,The wasm-bindgen Developers
 winapi,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>
 winapi-i686-pc-windows-gnu,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>
 winapi-x86_64-pc-windows-gnu,https://github.com/retep998/winapi-rs,Apache-2.0 OR MIT,Peter Atashian <retep998@gmail.com>

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
 use anyhow::Result;
-use async_std::{
+use smol::{
+    lock::{Barrier, RwLock},
     net::UdpSocket,
-    process::{Command, Stdio, Child, ExitStatus},
-    sync::{Arc, Barrier, RwLock},
-    task::{sleep, spawn},
+    process::{Child, Command, ExitStatus, Stdio},
+    Timer,
 };
 use serde_json::json;
 use std::{
@@ -16,6 +16,7 @@ use std::{
     env,
     os::unix::{io::{AsRawFd, FromRawFd, IntoRawFd, RawFd}, process::ExitStatusExt},
     process::exit,
+    sync::Arc,
 };
 use indexmap::IndexMap;
 
@@ -47,15 +48,19 @@ fn get_kernel_metrics(wall_time: f64, data: Rusage, metrics: &mut HashMap<String
 }
 
 async fn test_timeout(timeout: u64) {
-    sleep(std::time::Duration::from_secs(timeout)).await;
+    Timer::after(std::time::Duration::from_secs(timeout)).await;
     eprintln!("Timeout of {} seconds exceeded.", timeout);
     exit(1);
 }
 
 async fn read_one_byte(fd: RawFd) -> bool {
-    use async_std::io::ReadExt;
+    use smol::io::AsyncReadExt;
     let mut buf = [0u8; 1];
-    let mut f = unsafe { async_std::fs::File::from_raw_fd(fd) };
+    let file = unsafe { std::fs::File::from_raw_fd(fd) };
+    let mut f = match smol::Async::new(file) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
     f.read(&mut buf).await.map(|n| n > 0).unwrap_or(false)
 }
 
@@ -132,7 +137,7 @@ async fn run_with_instruction_count(
 
 async fn run_test(config: &Config, mut metrics: &mut HashMap<String, MetricValue>) -> Result<()> {
     if let Some(timeout) = config.timeout {
-        spawn(test_timeout(timeout));
+        smol::spawn(test_timeout(timeout)).detach();
     }
 
     let (read_fd, write_fd) = nix::unistd::pipe()?;
@@ -263,7 +268,7 @@ async fn main_main() -> Result<()> {
     let statsd_started = Arc::new(Barrier::new(2));
     let statsd_buf = Arc::new(RwLock::new(String::new()));
 
-    spawn(statsd_listener(statsd_started.clone(), statsd_buf.clone()));
+    smol::spawn(statsd_listener(statsd_started.clone(), statsd_buf.clone())).detach();
     statsd_started.wait().await; // waits for socket to be listening
 
     let mut iterations = Vec::new();
@@ -312,11 +317,12 @@ async fn iteration_main() -> Result<()> {
     Ok(())
 }
 
-#[async_std::main]
-async fn main() -> Result<()> {
-    if env::var("SIRUN_ITERATION").is_ok() {
-        iteration_main().await
-    } else {
-        main_main().await
-    }
+fn main() -> Result<()> {
+    smol::block_on(async {
+        if env::var("SIRUN_ITERATION").is_ok() {
+            iteration_main().await
+        } else {
+            main_main().await
+        }
+    })
 }

--- a/src/statsd.rs
+++ b/src/statsd.rs
@@ -1,10 +1,10 @@
 use crate::metric_value::*;
 use anyhow::Result;
-use async_std::{
+use smol::{
+    lock::{Barrier, RwLock},
     net::UdpSocket,
-    sync::{Arc, Barrier, RwLock},
 };
-use std::env;
+use std::{env, sync::Arc};
 use indexmap::IndexMap;
 
 pub(crate) async fn statsd_listener(

--- a/src/subproc.rs
+++ b/src/subproc.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
-use async_std::{
-    process::{Command, Child, Stdio},
-    task::sleep,
+use smol::{
+    process::{Child, Command, Stdio},
+    Timer,
 };
 use std::{collections::HashMap, env, os::unix::{io::RawFd, process::ExitStatusExt}, time::Duration};
 
@@ -33,7 +33,7 @@ async fn run_setup_or_teardown(typ: &str, config: &Config) -> Result<()> {
         if let Some(maybe_code) = maybe_code {
             code = maybe_code;
             if code != 0 {
-                sleep(Duration::from_secs(1)).await;
+                Timer::after(Duration::from_secs(1)).await;
                 attempts += 1;
             }
         } else {

--- a/src/summarize.rs
+++ b/src/summarize.rs
@@ -4,8 +4,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
 use anyhow::Result;
-use async_std::io;
 use indexmap::IndexMap;
+use smol::io::{AsyncBufReadExt, BufReader};
 
 use crate::metric_value::*;
 
@@ -64,7 +64,7 @@ fn summary(iterations: &[MetricValue]) -> MetricValue {
 }
 
 pub(crate) async fn summarize() -> Result<()> {
-    let stdin = io::stdin();
+    let mut stdin = BufReader::new(smol::Unblock::new(std::io::stdin()));
     let mut line = String::new();
     let mut result_data: MetricMap = IndexMap::new();
     while stdin.read_line(&mut line).await? != 0 {


### PR DESCRIPTION
## Summary

`async-std` was officially discontinued on 2025-03-01; upstream points all users at `smol`, the executor async-std was already built on. This swaps the runtime to `smol` with no behaviour change.

Two `smol` semantics differ from `async-std` and shape the diff:

1. A `smol` `Task` cancels when its handle drops, so the statsd listener and the timeout task are `.detach()`ed to stay fire-and-forget.
2. `async-process` drives its reaper thread from `Child` creation, so `child.status()` is awaited under a plain `block_on` with no executor wired up.

Net ~19 fewer transitive crates in the dependency tree.

## Note

Stacked on #79 — base is `BridgeAR/2026-06-03-dep-updates`; merge after #79 lands.

## Test plan

- [ ] `cargo test` on macOS and Ubuntu — 24 example tests, including `service` / `assigned_port` / `timeout` / `ready_signal_*` / `summarize`, which exercise the spawned listener, timer task, pipe read, and stdin path under the new runtime
- [ ] `cargo clippy --all-targets`

Refs: https://github.com/async-rs/async-std
